### PR TITLE
Add daily article fetcher

### DIFF
--- a/.github/workflows/article_content.yml
+++ b/.github/workflows/article_content.yml
@@ -1,0 +1,40 @@
+name: Fetch Article Content
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+jobs:
+  fetch:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+      - name: Install dependencies
+        run: |
+          pip install uv
+          uv pip install -e .
+      - name: Run article content scraper
+        run: python article_content_scraper.py
+      - name: Commit results
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git add data/article-content/
+          if ! git diff --staged --quiet; then
+            COMMIT_MSG="Update article content - $(date -u +'%Y-%m-%d %H:%M:%S UTC')"
+            git commit -m "$COMMIT_MSG"
+            git push
+          else
+            echo 'No changes to commit.'
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/scrape_bbc.yml
+++ b/.github/workflows/scrape_bbc.yml
@@ -33,7 +33,9 @@ jobs:
 
       # Step 3: Install Python dependencies from requirements.txt
       - name: Install dependencies
-        run: pip install -r requirements.txt
+        run: |
+          pip install uv
+          uv pip install -e .
 
       # Step 4: Run the Python scraper script
       - name: Run Scraper

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+      - name: Install dependencies
+        run: |
+          pip install uv
+          uv pip install -e .[dev]
+      - name: Run tests
+        run: pytest -vv

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ The scraped data is stored in CSV files within the `data/` directory.
 
 1. Clone the repository.
 2. Ensure Python 3.x is installed.
-3. Install dependencies:
+3. Install dependencies with [uv](https://github.com/astral-sh/uv):
  ```bash
- pip install -r requirements.txt
+ uv pip install -e .
  ```
 
 ## Running Manually (Optional)
@@ -32,6 +32,15 @@ python BBC_News_Most_Read_Scraper.py
 ```
 This will append data to the current day's CSV file in the `data/` directory.
 
+To fetch the full text of articles for yesterday's URLs:
+```bash
+python article_content_scraper.py
+```
+
 ## Automation
 
 The process is automated via GitHub Actions, running hourly and committing updated data files back to the repository.
+
+## Daily Article Content Fetch
+
+Each day at 02:00 UTC, the union of all URLs seen in the "Most Read" and front page promo logs from the previous day is fetched.  The full article HTML and a plain-text version are written to `data/article-content/{YYYY-MM-DD}.parquet`.

--- a/article_content_scraper.py
+++ b/article_content_scraper.py
@@ -1,0 +1,129 @@
+import asyncio
+import datetime as dt
+import logging
+from pathlib import Path
+from typing import List
+
+import aiohttp
+import pandas as pd
+from selectolax.parser import HTMLParser
+
+DATA_DIR = Path("data")
+ARTICLE_DIR = DATA_DIR / "article-content"
+HEADERS = {"User-Agent": "Mozilla/5.0"}
+
+
+def previous_date_str() -> str:
+    return (dt.datetime.utcnow().date() - dt.timedelta(days=1)).strftime("%Y-%m-%d")
+
+
+def load_url_log(date_str: str) -> pd.DataFrame:
+    paths = [
+        DATA_DIR / f"bbc_most_read_{date_str}.csv",
+        DATA_DIR / f"bbc_front_page_promos_{date_str}.csv",
+    ]
+    frames = []
+    for p in paths:
+        if not p.exists():
+            continue
+        df = pd.read_csv(p)
+        df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True)
+        df = df.rename(columns={"link": "url"})
+        frames.append(df[["timestamp", "url"]])
+    if not frames:
+        return pd.DataFrame(columns=["url", "first_appeared_at"])
+    df = pd.concat(frames, ignore_index=True)
+    df = df.sort_values("timestamp")
+    df = df.drop_duplicates("url", keep="first")
+    df = df.rename(columns={"timestamp": "first_appeared_at"})
+    return df.reset_index(drop=True)
+
+
+def parse_article_html(html: str):
+    tree = HTMLParser(html)
+    canonical = None
+    node = tree.css_first('link[rel="canonical"]')
+    if node and node.attributes.get("href"):
+        canonical = node.attributes["href"].strip()
+    title = ""
+    tnode = tree.css_first('meta[property="og:title"]')
+    if tnode and tnode.attributes.get("content"):
+        title = tnode.attributes["content"].strip()
+    if not title:
+        h1 = tree.css_first("h1")
+        if h1:
+            title = h1.text(strip=True)
+    authors = {a.text(strip=True) for a in tree.css('[rel="author"], [itemprop="name"]') if a.text(strip=True)}
+    meta_byl = tree.css_first('meta[name="byl"]')
+    if meta_byl and meta_byl.attributes.get('content'):
+        authors.add(meta_byl.attributes['content'].strip())
+    body_nodes = tree.css('[data-component="text-block"]')
+    if body_nodes:
+        article_html = "".join(n.html for n in body_nodes)
+        article_text = " ".join(n.text(separator=" ", strip=True) for n in body_nodes)
+    else:
+        main = tree.css_first("main") or tree.body
+        article_html = main.html if main else html
+        article_text = main.text(separator=" ", strip=True) if main else tree.text(separator=" ", strip=True)
+    return canonical, title, sorted(authors), article_html, article_text
+
+
+async def fetch_one(session: aiohttp.ClientSession, url: str):
+    await asyncio.sleep(0.1)  # rate limit 10 req/s
+    try:
+        async with session.get(url, headers=HEADERS, allow_redirects=True) as resp:
+            text = await resp.text()
+            ok = resp.status == 200
+            canonical, title, authors, article_html, article_text = parse_article_html(text)
+            return {
+                "url": canonical or str(resp.url),
+                "title": title,
+                "authors": ";".join(authors),
+                "article_html": article_html,
+                "article_text": article_text,
+                "fetch_ok": ok,
+            }
+    except Exception as exc:
+        logging.exception("Failed to fetch %s", url)
+        return {
+            "url": url,
+            "title": "",
+            "authors": "",
+            "article_html": "",
+            "article_text": "",
+            "fetch_ok": False,
+        }
+
+
+async def fetch_articles(url_df: pd.DataFrame) -> pd.DataFrame:
+    timeout = aiohttp.ClientTimeout(total=10)
+    connector = aiohttp.TCPConnector(limit=10)
+    async with aiohttp.ClientSession(timeout=timeout, connector=connector) as session:
+        tasks = [fetch_one(session, row.url) for row in url_df.itertuples(index=False)]
+        results = await asyncio.gather(*tasks)
+    for r, (_, first) in zip(results, url_df.itertuples(index=False)):
+        r["first_appeared_at"] = first
+    return pd.DataFrame(results)
+
+
+def save_parquet(df: pd.DataFrame, date_str: str) -> Path:
+    ARTICLE_DIR.mkdir(parents=True, exist_ok=True)
+    path = ARTICLE_DIR / f"{date_str}.parquet"
+    df.to_parquet(path, index=False)
+    return path
+
+
+def main():
+    logging.basicConfig(level=logging.INFO)
+    date_str = previous_date_str()
+    urls = load_url_log(date_str)
+    if urls.empty:
+        logging.info("No URLs found for %s", date_str)
+        return
+    df = asyncio.run(fetch_articles(urls))
+    save_parquet(df, date_str)
+    logging.info("Saved %d articles", len(df))
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+[project]
+name = "bbc_news_logger"
+version = "0.1.0"
+dependencies = [
+    "requests==2.31.0",
+    "beautifulsoup4==4.12.3",
+    "pandas==2.2.2",
+    "pyarrow==15.0.2",
+    "aiohttp==3.9.5",
+    "selectolax==0.3.17",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest==8.1.1",
+    "pytest-asyncio==0.23.5",
+]
+
+[build-system]
+requires = ["setuptools>=64", "wheel", "uv>=0.1.32"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["."]

--- a/tests/fixtures/art1.html
+++ b/tests/fixtures/art1.html
@@ -1,0 +1,11 @@
+<html>
+<head>
+<title>Article One</title>
+<link rel="canonical" href="http://example.com/one" />
+<meta property="og:title" content="Article One" />
+<meta name="byl" content="Author A" />
+</head>
+<body>
+<p data-component="text-block">Hello <b>World</b></p>
+</body>
+</html>

--- a/tests/fixtures/art2.html
+++ b/tests/fixtures/art2.html
@@ -1,0 +1,11 @@
+<html>
+<head>
+<title>Article Two</title>
+<link rel="canonical" href="http://example.com/two" />
+<meta property="og:title" content="Article Two" />
+</head>
+<body>
+<p data-component="text-block">Second article text</p>
+<p data-component="text-block">More text</p>
+</body>
+</html>

--- a/tests/test_article_scraper.py
+++ b/tests/test_article_scraper.py
@@ -1,0 +1,71 @@
+import asyncio
+from pathlib import Path
+import sys
+
+import pandas as pd
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from article_content_scraper import (
+    parse_article_html,
+    fetch_articles,
+)
+
+
+@pytest.fixture
+def url_df():
+    return pd.DataFrame({
+        "url": ["http://example.com/one", "http://example.com/one", "http://example.com/two"],
+        "first_appeared_at": [pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-02"), pd.Timestamp("2024-01-01")],
+    })
+
+
+def test_deduplication(url_df):
+    df = url_df.sort_values("first_appeared_at")
+    df = df.drop_duplicates("url", keep="first")
+    assert len(df) == 2
+    assert df.loc[df["url"] == "http://example.com/one", "first_appeared_at"].iloc[0] == pd.Timestamp("2024-01-01")
+
+
+def test_parse_article_html():
+    html = Path("tests/fixtures/art1.html").read_text()
+    canonical, title, authors, article_html, article_text = parse_article_html(html)
+    assert canonical == "http://example.com/one"
+    assert "Hello World" in article_text
+    assert "Author A" in authors
+
+
+class MockResponse:
+    def __init__(self, url, text):
+        self.url = url
+        self._text = text
+        self.status = 200
+
+    async def text(self):
+        return self._text
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_fetch_articles(monkeypatch, url_df):
+    html_map = {
+        "http://example.com/one": Path("tests/fixtures/art1.html").read_text(),
+        "http://example.com/two": Path("tests/fixtures/art2.html").read_text(),
+    }
+
+    def fake_get(self, url, **kwargs):
+        return MockResponse(url, html_map[url])
+
+    monkeypatch.setattr("aiohttp.ClientSession.get", fake_get, raising=False)
+
+    dedup = url_df.drop_duplicates("url", keep="first")
+    df = await fetch_articles(dedup)
+    assert len(df) == 2
+    assert df["fetch_ok"].all()
+    assert df["article_text"].notna().all()


### PR DESCRIPTION
## Summary
- add `article_content_scraper.py` to capture full articles to parquet
- manage dependencies with `pyproject.toml` and use uv in workflows
- add GitHub Actions workflow for daily article content job
- update existing scrape workflow to use uv
- provide unit and integration tests
- document new script and uv usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68513ab4445c8331a4d9b01232de7f75