### PR TITLE
Add data cleanup archiving routine

### DIFF
--- a/.github/workflows/data_cleanup.yml
+++ b/.github/workflows/data_cleanup.yml
@@ -1,0 +1,40 @@
+name: Cleanup BBC Data
+
+on:
+  schedule:
+    - cron: '30 3 * * 0'
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+      - name: Install dependencies
+        run: |
+          pip install uv
+          uv pip install -e . --system
+      - name: Archive old data files
+        run: python data_cleanup.py --retention-days 90
+      - name: Commit cleanup results
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git add data/
+          if ! git diff --staged --quiet; then
+            COMMIT_MSG="Archive old BBC data - $(date -u +'%Y-%m-%d %H:%M:%S UTC')"
+            git commit -m "$COMMIT_MSG"
+            git push
+          else
+            echo 'No cleanup changes to commit.'
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -12,8 +12,24 @@ A GitHub Actions workflow (`.github/workflows/scrape_bbc.yml`) runs this script 
 
 The scraped data is stored in CSV files within the `data/` directory.
 - A new file is created each day, named `bbc_most_read_YYYY-MM-DD.csv`.
+- Front-page promo logs are also stored daily as `bbc_front_page_promos_YYYY-MM-DD.csv`.
 - Each file contains entries for all scrapes performed on that UTC date.
-- Columns: `timestamp` (UTC time of scrape), `rank` (1-10), `title`, `link`.
+- Most-read columns: `timestamp` (UTC time of scrape), `rank` (1-10), `title`, `link`.
+- Front-page promo columns: `timestamp` (UTC time of scrape), `title`, `link`.
+
+## Data Cleanup
+
+To prevent the top-level `data/` folder from growing without bound, `data_cleanup.py` archives old daily files into monthly zip files under `data/archive/{category}/{YYYY}/{MM}.zip`. By default it keeps the most recent 90 days as loose files so the scrapers and yesterday's article-content fetch continue to work normally.
+
+Run a dry-run preview:
+```bash
+python data_cleanup.py --dry-run
+```
+
+Archive files older than the retention window:
+```bash
+python data_cleanup.py --retention-days 90
+```
 
 ## Setup
 

--- a/data_cleanup.py
+++ b/data_cleanup.py
@@ -1,0 +1,233 @@
+"""Archive old scraper outputs so the live data tree stays small.
+
+The scrapers need only the current day (and the article fetcher needs yesterday's
+CSV logs), so older daily files can be compressed into monthly zip archives.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import logging
+import re
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import Iterable, Sequence
+
+DATA_DIR = Path("data")
+DEFAULT_RETENTION_DAYS = 90
+
+CSV_PATTERNS = {
+    "bbc_most_read": re.compile(r"^bbc_most_read_(\d{4}-\d{2}-\d{2})\.csv$"),
+    "bbc_front_page_promos": re.compile(r"^bbc_front_page_promos_(\d{4}-\d{2}-\d{2})\.csv$"),
+}
+ARTICLE_CONTENT_PATTERN = re.compile(r"^(\d{4}-\d{2}-\d{2})\.parquet$")
+
+
+@dataclass(frozen=True)
+class CleanupCandidate:
+    """A dated data file that can be moved into a monthly archive."""
+
+    path: Path
+    date: dt.date
+    category: str
+    archive_name: str
+
+
+@dataclass(frozen=True)
+class CleanupSummary:
+    """Counts returned by the cleanup routine for logs and tests."""
+
+    archived_files: int
+    removed_files: int
+    archive_paths: tuple[Path, ...]
+    dry_run: bool
+
+
+def parse_iso_date(value: str) -> dt.date:
+    """Parse an ISO date from a scraper filename."""
+
+    return dt.datetime.strptime(value, "%Y-%m-%d").date()
+
+
+def cutoff_date(retention_days: int, today: dt.date | None = None) -> dt.date:
+    """Return the oldest date that should remain unarchived."""
+
+    if retention_days < 1:
+        raise ValueError("retention_days must be at least 1")
+    today = today or dt.datetime.now(dt.timezone.utc).date()
+    return today - dt.timedelta(days=retention_days)
+
+
+def archive_path_for(data_dir: Path, candidate: CleanupCandidate) -> Path:
+    """Return the monthly zip path for a cleanup candidate."""
+
+    return (
+        data_dir
+        / "archive"
+        / candidate.category
+        / f"{candidate.date:%Y}"
+        / f"{candidate.date:%m}.zip"
+    )
+
+
+def iter_cleanup_candidates(data_dir: Path, cutoff: dt.date) -> Iterable[CleanupCandidate]:
+    """Yield daily CSV and article-content parquet files older than cutoff."""
+
+    if not data_dir.exists():
+        return
+
+    for path in sorted(data_dir.glob("*.csv")):
+        for category, pattern in CSV_PATTERNS.items():
+            match = pattern.match(path.name)
+            if not match:
+                continue
+            file_date = parse_iso_date(match.group(1))
+            if file_date < cutoff:
+                yield CleanupCandidate(
+                    path=path,
+                    date=file_date,
+                    category=category,
+                    archive_name=path.relative_to(data_dir).as_posix(),
+                )
+            break
+
+    article_dir = data_dir / "article-content"
+    if not article_dir.exists():
+        return
+
+    for path in sorted(article_dir.glob("*.parquet")):
+        match = ARTICLE_CONTENT_PATTERN.match(path.name)
+        if not match:
+            continue
+        file_date = parse_iso_date(match.group(1))
+        if file_date < cutoff:
+            yield CleanupCandidate(
+                path=path,
+                date=file_date,
+                category="article-content",
+                archive_name=path.relative_to(data_dir).as_posix(),
+            )
+
+
+def write_archive(archive_path: Path, candidates: Sequence[CleanupCandidate]) -> None:
+    """Write candidates into an archive, replacing matching entries if present."""
+
+    archive_path.parent.mkdir(parents=True, exist_ok=True)
+    replacement_names = {candidate.archive_name for candidate in candidates}
+
+    with NamedTemporaryFile(
+        prefix=f".{archive_path.name}.",
+        suffix=".tmp",
+        dir=archive_path.parent,
+        delete=False,
+    ) as tmp:
+        temp_path = Path(tmp.name)
+
+    try:
+        with zipfile.ZipFile(temp_path, "w", compression=zipfile.ZIP_DEFLATED) as output_zip:
+            if archive_path.exists():
+                with zipfile.ZipFile(archive_path, "r") as existing_zip:
+                    for info in existing_zip.infolist():
+                        if info.filename in replacement_names:
+                            continue
+                        output_zip.writestr(info, existing_zip.read(info.filename))
+
+            for candidate in sorted(candidates, key=lambda item: item.archive_name):
+                output_zip.write(candidate.path, candidate.archive_name)
+
+        temp_path.replace(archive_path)
+    except Exception:
+        temp_path.unlink(missing_ok=True)
+        raise
+
+
+def cleanup_data(
+    data_dir: Path = DATA_DIR,
+    retention_days: int = DEFAULT_RETENTION_DAYS,
+    today: dt.date | None = None,
+    dry_run: bool = False,
+) -> CleanupSummary:
+    """Archive old files and remove the now-compressed originals."""
+
+    data_dir = Path(data_dir)
+    cutoff = cutoff_date(retention_days, today)
+    candidates = list(iter_cleanup_candidates(data_dir, cutoff))
+    archive_groups: dict[Path, list[CleanupCandidate]] = {}
+    for candidate in candidates:
+        archive_groups.setdefault(archive_path_for(data_dir, candidate), []).append(candidate)
+
+    for archive_path, grouped_candidates in sorted(archive_groups.items()):
+        logging.info(
+            "%s %d file(s) into %s",
+            "Would archive" if dry_run else "Archiving",
+            len(grouped_candidates),
+            archive_path,
+        )
+        if not dry_run:
+            write_archive(archive_path, grouped_candidates)
+
+    removed = 0
+    for candidate in candidates:
+        logging.info(
+            "%s %s",
+            "Would remove" if dry_run else "Removing archived source",
+            candidate.path,
+        )
+        if not dry_run:
+            candidate.path.unlink()
+            removed += 1
+
+    return CleanupSummary(
+        archived_files=len(candidates),
+        removed_files=0 if dry_run else removed,
+        archive_paths=tuple(sorted(archive_groups)),
+        dry_run=dry_run,
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Archive old BBC scraper data files into monthly zip files."
+    )
+    parser.add_argument(
+        "--data-dir",
+        type=Path,
+        default=DATA_DIR,
+        help="Data directory to clean up (default: data).",
+    )
+    parser.add_argument(
+        "--retention-days",
+        type=int,
+        default=DEFAULT_RETENTION_DAYS,
+        help=f"Keep this many recent days as loose files (default: {DEFAULT_RETENTION_DAYS}).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Log what would be archived without changing files.",
+    )
+    return parser
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(message)s")
+    args = build_parser().parse_args()
+    summary = cleanup_data(
+        data_dir=args.data_dir,
+        retention_days=args.retention_days,
+        dry_run=args.dry_run,
+    )
+    logging.info(
+        "%s %d file(s) across %d archive(s); removed %d source file(s).",
+        "Would archive" if summary.dry_run else "Archived",
+        summary.archived_files,
+        len(summary.archive_paths),
+        summary.removed_files,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_data_cleanup.py
+++ b/tests/test_data_cleanup.py
@@ -1,0 +1,71 @@
+import datetime as dt
+import zipfile
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from data_cleanup import cleanup_data, iter_cleanup_candidates
+
+
+def write_file(path: Path, text: str = "content") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+
+
+def test_cleanup_archives_old_daily_files_by_category_and_month(tmp_path):
+    data_dir = tmp_path / "data"
+    write_file(data_dir / "bbc_most_read_2024-01-01.csv", "rank,title\n1,old")
+    write_file(data_dir / "bbc_front_page_promos_2024-01-02.csv", "title\nold")
+    write_file(data_dir / "article-content" / "2024-01-03.parquet", "parquet-ish")
+    write_file(data_dir / "bbc_most_read_2024-04-15.csv", "rank,title\n1,new")
+    write_file(data_dir / "notes.txt", "ignore me")
+
+    summary = cleanup_data(
+        data_dir=data_dir,
+        retention_days=90,
+        today=dt.date(2024, 4, 15),
+    )
+
+    assert summary.archived_files == 3
+    assert summary.removed_files == 3
+    assert not (data_dir / "bbc_most_read_2024-01-01.csv").exists()
+    assert not (data_dir / "bbc_front_page_promos_2024-01-02.csv").exists()
+    assert not (data_dir / "article-content" / "2024-01-03.parquet").exists()
+    assert (data_dir / "bbc_most_read_2024-04-15.csv").exists()
+    assert (data_dir / "notes.txt").exists()
+
+    with zipfile.ZipFile(data_dir / "archive" / "bbc_most_read" / "2024" / "01.zip") as archive:
+        assert archive.read("bbc_most_read_2024-01-01.csv") == b"rank,title\n1,old"
+    with zipfile.ZipFile(data_dir / "archive" / "bbc_front_page_promos" / "2024" / "01.zip") as archive:
+        assert archive.read("bbc_front_page_promos_2024-01-02.csv") == b"title\nold"
+    with zipfile.ZipFile(data_dir / "archive" / "article-content" / "2024" / "01.zip") as archive:
+        assert archive.read("article-content/2024-01-03.parquet") == b"parquet-ish"
+
+
+def test_cleanup_dry_run_does_not_change_files(tmp_path):
+    data_dir = tmp_path / "data"
+    old_file = data_dir / "bbc_most_read_2024-01-01.csv"
+    write_file(old_file)
+
+    summary = cleanup_data(
+        data_dir=data_dir,
+        retention_days=30,
+        today=dt.date(2024, 3, 1),
+        dry_run=True,
+    )
+
+    assert summary.archived_files == 1
+    assert summary.removed_files == 0
+    assert old_file.exists()
+    assert not (data_dir / "archive").exists()
+
+
+def test_iter_cleanup_candidates_skips_cutoff_date(tmp_path):
+    data_dir = tmp_path / "data"
+    write_file(data_dir / "bbc_most_read_2024-01-31.csv")
+    write_file(data_dir / "bbc_most_read_2024-02-01.csv")
+
+    candidates = list(iter_cleanup_candidates(data_dir, dt.date(2024, 2, 1)))
+
+    assert [candidate.path.name for candidate in candidates] == ["bbc_most_read_2024-01-31.csv"]


### PR DESCRIPTION
### Motivation
- The repository's top-level `data/` folder accumulates daily CSV and article parquet files and grows without bound, so older files need to be archived to keep the live dataset small.
- Scrapers and the article fetcher only require the most recent loose files (today / yesterday), so older daily files can be compressed into monthly archives to reduce disk footprint.

### Description
- Add `data_cleanup.py`, a CLI utility that finds dated `bbc_most_read_*.csv`, `bbc_front_page_promos_*.csv` and `data/article-content/*.parquet` older than a configurable retention and writes them into monthly zip archives under `data/archive/{category}/{YYYY}/{MM}.zip`, replacing matching entries if present and removing originals after successful archiving (no-op when `--dry-run`).
- Provide CLI flags `--data-dir`, `--retention-days`, and `--dry-run` and default the retention window to 90 days; helper functions include `iter_cleanup_candidates`, `archive_path_for`, and `cleanup_data` for testability.
- Add tests in `tests/test_data_cleanup.py` that verify monthly/category archive creation, dry-run safety, and cutoff-date handling, and update `README.md` with usage examples for `--dry-run` and `--retention-days`.
- Add a new GitHub Actions workflow `.github/workflows/data_cleanup.yml` to run the cleanup on a weekly schedule (and on demand) and commit archive/deletion results when present.

### Testing
- Ran the full test suite with `PYENV_VERSION=3.10.20 pytest -q`, and all tests passed (`6 passed`).
- Performed a dry-run with `PYENV_VERSION=3.10.20 python data_cleanup.py --dry-run --retention-days 90` to verify candidate discovery and logging of the expected archive/remove actions, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a296eaeda648331b598d1e940590f97)