### PR TITLE
Report semantic checkpoint progress

### DIFF
--- a/services/fenic/enrich.py
+++ b/services/fenic/enrich.py
@@ -39,6 +39,7 @@ from bbc_news_logger.storage import write_parquet
 
 MAX_BACKFILL_BUDGET_USD = Decimal("7.50")
 MAX_MONTHLY_BUDGET_USD = Decimal("1.00")
+REMOTE_SIGNAL_SHARD_ROWS = MAX_BATCH_SIZE * 4
 
 
 @dataclass(frozen=True)
@@ -134,7 +135,7 @@ def enrich(
         ]
         published_from_checkpoint = 0
         if publish:
-            for rows in _batches(local_rows, MAX_BATCH_SIZE):
+            for rows in _batches(local_rows, REMOTE_SIGNAL_SHARD_ROWS):
                 table = pa.Table.from_pylist(rows, schema=SIGNAL_SCHEMA)
                 publish_shard(
                     table,
@@ -153,6 +154,22 @@ def enrich(
             if row["content_sha256"] not in done and row["content_sha256"] not in failed
         ]
         selected = candidates[:limit] if limit > 0 else candidates
+        print(
+            json.dumps(
+                {
+                    "event": "deepseek_start",
+                    "scope": scope,
+                    "prior_scope_spend_usd": float(prior_spend),
+                    "process_budget_usd": float(process_cap),
+                    "candidates": len(candidates),
+                    "selected": len(selected),
+                    "batch_size": batch_size,
+                    "concurrency": concurrency,
+                },
+                sort_keys=True,
+            ),
+            flush=True,
+        )
         pending_batches = _batches(selected, batch_size)
         output_dir.mkdir(parents=True, exist_ok=True)
         api_requests = 0
@@ -179,6 +196,7 @@ def enrich(
                 break
 
             futures: dict[Future[DeepSeekBatchResult], list[dict[str, Any]]] = {}
+            wave_rows: list[dict[str, Any]] = []
             with ThreadPoolExecutor(max_workers=concurrency) as executor:
                 for batch, _reservation in wave:
                     futures[executor.submit(_request, client, batch)] = batch
@@ -197,15 +215,42 @@ def enrich(
                     table = pa.Table.from_pylist(rows, schema=SIGNAL_SCHEMA)
                     local_path = output_dir / f"{result.response_id or hashes[0]}.parquet"
                     write_parquet(table, local_path)
-                    if publish:
-                        publish_shard(
-                            table,
-                            prefix=SIGNAL_PREFIX,
-                            dataset_id=dataset_id,
-                            message=f"Checkpoint {len(rows)} DeepSeek story signals",
-                        )
+                    wave_rows.extend(rows)
                     api_requests += 1
                     rows_added += len(rows)
+                    print(
+                        json.dumps(
+                            {
+                                "event": "deepseek_response_checkpoint",
+                                "api_requests": api_requests,
+                                "rows_added": rows_added,
+                                "response_rows": len(rows),
+                                "spent_usd": float(budget.spent_usd),
+                            },
+                            sort_keys=True,
+                        ),
+                        flush=True,
+                    )
+            if publish and wave_rows:
+                wave_table = pa.Table.from_pylist(wave_rows, schema=SIGNAL_SCHEMA)
+                remote_path = publish_shard(
+                    wave_table,
+                    prefix=SIGNAL_PREFIX,
+                    dataset_id=dataset_id,
+                    message=f"Checkpoint {len(wave_rows)} DeepSeek story signals",
+                )
+                print(
+                    json.dumps(
+                        {
+                            "event": "deepseek_remote_checkpoint",
+                            "rows_in_shard": len(wave_rows),
+                            "rows_added": rows_added,
+                            "path": remote_path,
+                        },
+                        sort_keys=True,
+                    ),
+                    flush=True,
+                )
 
         return EnrichmentReport(
             model=DEEPSEEK_MODEL,

--- a/src/bbc_news_logger/semantics.py
+++ b/src/bbc_news_logger/semantics.py
@@ -359,6 +359,20 @@ def run_embedding_refresh(
     )
     candidates = [row for row in articles if row["content_sha256"] not in done]
     selected = candidates[:limit] if limit > 0 else candidates
+    print(
+        json.dumps(
+            {
+                "event": "embedding_start",
+                "model": EMBEDDING_MODEL,
+                "completed": len(done),
+                "candidates": len(candidates),
+                "selected": len(selected),
+                "batch_size": batch_size,
+            },
+            sort_keys=True,
+        ),
+        flush=True,
+    )
     model = embedder or _default_embedder()
     added = 0
     shards = 0
@@ -390,8 +404,9 @@ def run_embedding_refresh(
         table = pa.Table.from_pylist(rows, schema=EMBEDDING_SCHEMA)
         local_path = output_dir / Path(shard_path(EMBEDDING_PREFIX, rows)).name
         write_parquet(table, local_path)
+        published_path = None
         if publish:
-            publish_shard(
+            published_path = publish_shard(
                 table,
                 prefix=EMBEDDING_PREFIX,
                 dataset_id=dataset_id,
@@ -399,6 +414,20 @@ def run_embedding_refresh(
             )
             shards += 1
         added += len(rows)
+        print(
+            json.dumps(
+                {
+                    "event": "embedding_checkpoint",
+                    "rows_in_shard": len(rows),
+                    "rows_added": added,
+                    "selected": len(selected),
+                    "remaining_after_run": max(0, len(candidates) - added),
+                    "path": published_path or str(local_path),
+                },
+                sort_keys=True,
+            ),
+            flush=True,
+        )
     return EmbeddingReport(
         model=EMBEDDING_MODEL,
         candidates=len(candidates),

--- a/tests/test_semantics.py
+++ b/tests/test_semantics.py
@@ -93,7 +93,9 @@ def test_sqlite_checkpoint_survives_reopen(tmp_path) -> None:
     restored.close()
 
 
-def test_embedding_refresh_normalizes_and_checkpoints_batch(monkeypatch, tmp_path) -> None:
+def test_embedding_refresh_normalizes_and_reports_checkpoint(
+    monkeypatch, tmp_path, capsys
+) -> None:
     start = datetime(2026, 7, 1, tzinfo=timezone.utc)
     article_table = pa.Table.from_pylist(
         [_article("hash-a", "Talks begin", start)], schema=ARTICLE_SCHEMA
@@ -119,6 +121,10 @@ def test_embedding_refresh_normalizes_and_checkpoints_batch(monkeypatch, tmp_pat
     table = pq.read_table(next(tmp_path.glob("*.parquet")))
     vector = table.column("embedding")[0].as_py()
     assert vector[:2] == pytest.approx([0.6, 0.8])
+    output = capsys.readouterr().out
+    assert '"event": "embedding_start"' in output
+    assert '"event": "embedding_checkpoint"' in output
+    assert '"rows_added": 1' in output
 
 
 def test_clustering_joins_same_event_but_not_nearby_unrelated_story() -> None:


### PR DESCRIPTION
## What changed

- print structured start and checkpoint progress during BGE and DeepSeek runs
- keep every paid response in the synchronous SQLite checkpoint immediately
- combine each four-request DeepSeek wave into one remote Parquet shard and Hugging Face commit
- publish previously local-only checkpoint rows in the same 32-row groups on resume

## Why

The active BGE run is progressing through Hugging Face commits, but its Actions log does not expose that progress. The paid phase would also create one remote commit per eight articles. Wave-level remote shards retain the paid-call safety boundary while reducing expected historical commit volume by roughly four times.

## Validation

- `ruff check .`
- `pytest -q` (21 passed)
- `git diff --check`

The active embedding-only run uses the previous commit and is unaffected.
