### PR TITLE
Reduce Hugging Face semantic checkpoint commits

### DIFF
--- a/.github/workflows/semantics.yml
+++ b/.github/workflows/semantics.yml
@@ -71,6 +71,7 @@ jobs:
             --scope "$SEMANTIC_SCOPE" \
             --publish
       - name: Rebuild recurring-story clusters
+        if: ${{ always() && !cancelled() }}
         shell: bash
         run: |
           if ! uv run --no-sync python -m services.fenic.cluster --publish; then

--- a/README.md
+++ b/README.md
@@ -102,9 +102,11 @@ which writes completed batches back to the Hugging Face dataset without rebuildi
 Semantic enrichment runs explicitly on a local machine with
 `./scripts/refresh_semantics.sh`. It bills only new content hashes and writes each successful
 eight-article response to a synchronous SQLite checkpoint before starting more paid work. Up to
-four requests run concurrently, and each completed batch is uploaded as an immutable Parquet
-shard. A hard `$1.00` process ceiling, `$7.50` historical ceiling, and `$1.00` monthly incremental
-ceiling limit spend. Ambiguous network failures are recorded without automatic paid retries.
+four requests run concurrently, and completed responses are buffered into 256-row immutable
+Parquet shards before upload. This keeps paid-call recovery granular without exhausting the Hugging
+Face repository commit quota. A hard `$1.00` process ceiling, `$7.50` historical ceiling, and
+`$1.00` monthly incremental ceiling limit spend. Ambiguous model failures are recorded without
+automatic paid retries; a Hub commit-rate response waits for its quota window and retries once.
 
 The resulting Signals dashboard shows theme, topic, story-form, and event-type trends plus
 recurring-story timelines. Coverage is always visible because historical enrichment can take more

--- a/services/fenic/README.md
+++ b/services/fenic/README.md
@@ -45,7 +45,8 @@ are sent in one request. Four requests may run concurrently. Content hashes avoi
 
 The process calculates cost from DeepSeek's returned token counters and writes a run manifest to
 `dist/semantic-run.json`. Each successful response is committed to a synchronous SQLite WAL before
-the next wave starts and is uploaded as an immutable Parquet shard when publishing is enabled.
+the next wave starts. Publishing buffers those responses into immutable 256-row Parquet shards,
+reducing Hugging Face commits while retaining per-response paid-call recovery locally.
 The budget defaults to `$1.00` and the code rejects any higher process value. Persistent dataset
 rows enforce the separate `$7.50` backfill and `$1.00` monthly ledgers.
 

--- a/services/fenic/enrich.py
+++ b/services/fenic/enrich.py
@@ -33,13 +33,14 @@ from bbc_news_logger.semantics import (
     download_dataset_tables,
     publish_shard,
     signal_rows_from_batch,
+    take_ready_shard,
     unique_article_rows,
 )
 from bbc_news_logger.storage import write_parquet
 
 MAX_BACKFILL_BUDGET_USD = Decimal("7.50")
 MAX_MONTHLY_BUDGET_USD = Decimal("1.00")
-REMOTE_SIGNAL_SHARD_ROWS = MAX_BATCH_SIZE * 4
+REMOTE_SIGNAL_SHARD_ROWS = MAX_BATCH_SIZE * 32
 
 
 @dataclass(frozen=True)
@@ -93,6 +94,38 @@ def _request(client: DeepSeekClient, batch: list[dict[str, Any]]) -> DeepSeekBat
     return client.enrich_batch(
         [(str(row["content_sha256"]), str(row["article_text"])) for row in batch]
     )
+
+
+def _publish_ready_rows(
+    rows: list[dict[str, Any]],
+    *,
+    dataset_id: str,
+    rows_added: int,
+    force: bool,
+) -> None:
+    while shard_rows := take_ready_shard(
+        rows, shard_size=REMOTE_SIGNAL_SHARD_ROWS, force=force
+    ):
+        table = pa.Table.from_pylist(shard_rows, schema=SIGNAL_SCHEMA)
+        remote_path = publish_shard(
+            table,
+            prefix=SIGNAL_PREFIX,
+            dataset_id=dataset_id,
+            message=f"Checkpoint {len(shard_rows)} DeepSeek story signals",
+        )
+        print(
+            json.dumps(
+                {
+                    "event": "deepseek_remote_checkpoint",
+                    "rows_in_shard": len(shard_rows),
+                    "rows_added": rows_added,
+                    "rows_waiting_for_publish": len(rows),
+                    "path": remote_path,
+                },
+                sort_keys=True,
+            ),
+            flush=True,
+        )
 
 
 def enrich(
@@ -175,6 +208,7 @@ def enrich(
         api_requests = 0
         rows_added = 0
         failure_count = 0
+        rows_waiting_for_publish: list[dict[str, Any]] = []
         stopped_for_budget = process_cap <= 0 and bool(pending_batches)
         budget = RunBudget(process_cap) if process_cap > 0 else None
 
@@ -232,25 +266,21 @@ def enrich(
                         flush=True,
                     )
             if publish and wave_rows:
-                wave_table = pa.Table.from_pylist(wave_rows, schema=SIGNAL_SCHEMA)
-                remote_path = publish_shard(
-                    wave_table,
-                    prefix=SIGNAL_PREFIX,
+                rows_waiting_for_publish.extend(wave_rows)
+                _publish_ready_rows(
+                    rows_waiting_for_publish,
                     dataset_id=dataset_id,
-                    message=f"Checkpoint {len(wave_rows)} DeepSeek story signals",
+                    rows_added=rows_added,
+                    force=False,
                 )
-                print(
-                    json.dumps(
-                        {
-                            "event": "deepseek_remote_checkpoint",
-                            "rows_in_shard": len(wave_rows),
-                            "rows_added": rows_added,
-                            "path": remote_path,
-                        },
-                        sort_keys=True,
-                    ),
-                    flush=True,
-                )
+
+        if publish:
+            _publish_ready_rows(
+                rows_waiting_for_publish,
+                dataset_id=dataset_id,
+                rows_added=rows_added,
+                force=True,
+            )
 
         return EnrichmentReport(
             model=DEEPSEEK_MODEL,

--- a/src/bbc_news_logger/semantics.py
+++ b/src/bbc_news_logger/semantics.py
@@ -8,6 +8,7 @@ import math
 import os
 import sqlite3
 import tempfile
+import time
 from collections.abc import Iterable, Sequence
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
@@ -17,6 +18,7 @@ from typing import Any, Protocol
 import pyarrow as pa
 import pyarrow.parquet as pq
 from huggingface_hub import HfApi, snapshot_download
+from huggingface_hub.errors import HfHubHTTPError
 
 from .config import DEFAULT_DATASET_ID
 from .deepseek import DEEPSEEK_MODEL, PROMPT_VERSION, DeepSeekBatchResult
@@ -27,6 +29,8 @@ EMBEDDING_MODEL_REVISION = "main"
 EMBEDDING_INPUT_VERSION = "headline-body-lead-v1"
 EMBEDDING_DIMENSIONS = 384
 EMBEDDING_TEXT_CHARACTERS = 4_000
+HF_UPLOAD_MAX_ATTEMPTS = 2
+HF_COMMIT_RATE_LIMIT_DELAY_SECONDS = 3_600
 
 SIGNAL_PREFIX = "semantic/signals"
 EMBEDDING_PREFIX = "semantic/embeddings"
@@ -228,14 +232,58 @@ def publish_shard(
     path = shard_path(prefix, rows)
     with tempfile.TemporaryDirectory(prefix="bbc-news-semantic-shard-") as tmp:
         local = write_parquet(table, Path(tmp) / "shard.parquet")
-        HfApi(token=token or os.getenv("HF_TOKEN")).upload_file(
-            repo_id=dataset_id,
-            repo_type="dataset",
-            path_or_fileobj=local,
-            path_in_repo=path,
-            commit_message=message,
-        )
+        api = HfApi(token=token or os.getenv("HF_TOKEN"))
+        for attempt in range(1, HF_UPLOAD_MAX_ATTEMPTS + 1):
+            try:
+                api.upload_file(
+                    repo_id=dataset_id,
+                    repo_type="dataset",
+                    path_or_fileobj=local,
+                    path_in_repo=path,
+                    commit_message=message,
+                )
+                break
+            except HfHubHTTPError as exc:
+                response = exc.response
+                if (
+                    response is None
+                    or response.status_code != 429
+                    or attempt == HF_UPLOAD_MAX_ATTEMPTS
+                ):
+                    raise
+                retry_after = response.headers.get("Retry-After")
+                try:
+                    delay = max(1, int(float(retry_after or 0)))
+                except ValueError:
+                    delay = 60
+                if "repository commits" in str(exc).lower():
+                    delay = max(delay, HF_COMMIT_RATE_LIMIT_DELAY_SECONDS)
+                print(
+                    json.dumps(
+                        {
+                            "event": "hf_upload_retry",
+                            "attempt": attempt,
+                            "delay_seconds": delay,
+                            "path": path,
+                        },
+                        sort_keys=True,
+                    ),
+                    flush=True,
+                )
+                time.sleep(delay)
     return path
+
+
+def take_ready_shard(
+    rows: list[dict[str, Any]], *, shard_size: int, force: bool
+) -> list[dict[str, Any]]:
+    """Remove one publishable shard while retaining a smaller in-memory buffer."""
+    if len(rows) < shard_size and not (force and rows):
+        return []
+    count = min(len(rows), shard_size)
+    shard = rows[:count]
+    del rows[:count]
+    return shard
 
 
 class SemanticCheckpoint:

--- a/tests/test_semantics.py
+++ b/tests/test_semantics.py
@@ -5,6 +5,8 @@ from datetime import datetime, timedelta, timezone
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
+from httpx import Request, Response
+from huggingface_hub.errors import HfHubHTTPError
 
 from bbc_news_logger.clustering import cluster_events
 from bbc_news_logger.semantics import (
@@ -13,7 +15,9 @@ from bbc_news_logger.semantics import (
     SIGNAL_SCHEMA,
     SemanticCheckpoint,
     embedding_text,
+    publish_shard,
     run_embedding_refresh,
+    take_ready_shard,
 )
 from bbc_news_logger.storage import ARTICLE_SCHEMA
 
@@ -91,6 +95,59 @@ def test_sqlite_checkpoint_survives_reopen(tmp_path) -> None:
     assert restored.completed_hashes() == {"hash-a"}
     assert restored.rows()[0]["event_label"] == "Talks resume"
     restored.close()
+
+
+def test_publish_shard_waits_for_hugging_face_commit_rate_limit(
+    monkeypatch, capsys
+) -> None:
+    start = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    table = pa.Table.from_pylist([_signal("hash-a", "Talks", "State", start)], SIGNAL_SCHEMA)
+    request = Request("POST", "https://huggingface.co/api/datasets/example/commit/main")
+    response = Response(429, headers={"Retry-After": "68"}, request=request)
+    error = HfHubHTTPError(
+        "You have exceeded the rate limit for repository commits (128 per hour).",
+        response=response,
+    )
+
+    class FakeApi:
+        attempts = 0
+
+        def upload_file(self, **_kwargs):
+            self.attempts += 1
+            if self.attempts == 1:
+                raise error
+
+    api = FakeApi()
+    delays: list[int] = []
+    monkeypatch.setattr("bbc_news_logger.semantics.HfApi", lambda **_kwargs: api)
+    monkeypatch.setattr("bbc_news_logger.semantics.time.sleep", delays.append)
+
+    path = publish_shard(
+        table,
+        prefix="semantic/signals",
+        dataset_id="example/dataset",
+        message="test",
+    )
+
+    assert path.endswith(".parquet")
+    assert api.attempts == 2
+    assert delays == [3_600]
+    assert '"event": "hf_upload_retry"' in capsys.readouterr().out
+
+
+def test_take_ready_shard_buffers_rows_until_target_size() -> None:
+    rows = [{"content_sha256": f"hash-{index}"} for index in range(300)]
+
+    first = take_ready_shard(rows, shard_size=256, force=False)
+
+    assert len(first) == 256
+    assert len(rows) == 44
+    assert take_ready_shard(rows, shard_size=256, force=False) == []
+
+    final = take_ready_shard(rows, shard_size=256, force=True)
+
+    assert len(final) == 44
+    assert rows == []
 
 
 def test_embedding_refresh_normalizes_and_reports_checkpoint(


### PR DESCRIPTION
## What changed

- buffer DeepSeek results into 256-row Hugging Face shards instead of committing every four-request wave
- retain the synchronous SQLite checkpoint after every paid response
- wait for the repository commit quota window and retry once on a Hugging Face 429
- rebuild clusters from already-published data even if enrichment fails
- document and test the two-layer checkpoint strategy

## Root cause

The historical run published 16–32 rows per Hugging Face commit. Combined with the embedding backfill, this exceeded the Hub's 128 repository commits per hour limit and aborted enrichment after 2,432 locally checkpointed labels.

## Impact

A comparable 2,432-row enrichment now needs about 10 Hub commits instead of roughly 76, while every paid response remains durable in SQLite. If the Hub still returns its commit-quota 429, the workflow waits for the quota window rather than failing immediately.

## Verification

- `.venv/bin/ruff check .`
- `.venv/bin/python -m pytest -q` — 23 passed
- workflow YAML parsed with PyYAML
- Python sources compiled with `compileall`
