### PR TITLE
Pin Worker deploy to Wrangler 4

### DIFF
--- a/.github/workflows/research_worker.yml
+++ b/.github/workflows/research_worker.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           apiToken: ${{ env.CF_API_TOKEN }}
           accountId: ${{ env.CF_ACCOUNT_ID }}
+          wranglerVersion: "4.110.0"
           workingDirectory: workers/research
           command: deploy
           secrets: |


### PR DESCRIPTION
## Fix

Pin `cloudflare/wrangler-action` to Wrangler 4.110.0, the version used by the successful local dry-run.

The first live deployment installed Wrangler 3.90.0. That version ignored `wrangler.jsonc`, so the secret-upload step failed with `Required Worker name missing` before making any deployment.

No credentials or runtime behavior change. The Worker contract already passes its Node tests and Wrangler 4 dry-run.