### PR TITLE
Keep Worker deployments green

### DIFF
--- a/.github/workflows/research_worker.yml
+++ b/.github/workflows/research_worker.yml
@@ -14,7 +14,6 @@ concurrency:
 
 permissions:
   contents: read
-  actions: write
 
 jobs:
   deploy:
@@ -42,14 +41,6 @@ jobs:
             DEEPSEEK_API_KEY
         env:
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY || secrets.DEEPSEEK_API }}
-      - name: Point Pages at the deployed Worker
-        if: steps.deploy.outputs.deployment-url != ''
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DEPLOYMENT_URL: ${{ steps.deploy.outputs.deployment-url }}
-        run: |
-          gh variable set PUBLIC_RESEARCH_API_URL --body "${DEPLOYMENT_URL%/}/api/research"
-          gh workflow run pages.yml
       - name: Explain skipped deployment
         if: env.CF_API_TOKEN == '' || env.CF_ACCOUNT_ID == ''
         run: echo "::notice::Add CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID to deploy the tested Worker."

--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@ limited key in session storage for the current tab and sends it directly to Deep
 Hugging Face currently permits only Static Spaces on the free account used here, so no dormant
 Gradio deployment is retained.
 
+Worker deployment uses the `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` GitHub secrets. Pages
+reads its endpoint from the `PUBLIC_RESEARCH_API_URL` repository variable; for this repository it is
+`https://bbc-news-archive-research.alastairherd.workers.dev/api/research`.
+
 ## Semantic backfill
 
 The Raspberry Pi does not run the embedding model. Start `Refresh semantic analysis` manually


### PR DESCRIPTION
The Worker deployed successfully, but the workflow's restricted `GITHUB_TOKEN` received HTTP 403 when trying to create a repository variable, marking the otherwise successful deployment red.

This removes that unsupported self-configuration step and documents the stable endpoint. `PUBLIC_RESEARCH_API_URL` has already been configured through the authenticated repository session and Pages has been dispatched.

Live verification:
- health endpoint reports Cloudflare Workers + `deepseek-v4-flash`
- bounded cited query succeeded for $0.00021994
- an identical repeat returned `cached: true` without another model call