### PR TITLE
Improve BBC News Analyser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# BBC News Surface Lab
+# BBC News Analyser
 
-An independent longitudinal dataset and research interface for studying how stories move between
-the BBC News front page and Most Read list.
+An independent longitudinal dataset and research interface for studying how stories, themes, and
+recurring events move between the BBC News front page and Most Read list.
 
 - **Explore:** <https://alastairherd.github.io/bbc_news_logger/>
 - **Curated dataset:** <https://huggingface.co/datasets/AlastairH/bbc-news-logger>
@@ -85,6 +85,7 @@ reconstructed front-page position, selector risk, and interpretive limits.
 | Fetch daily article snapshots | Daily at `02:17 UTC` | Fetches the previous day's distinct URLs with a global request-rate limiter |
 | Refresh semantic analysis | After the daily article job | Embeds and labels only new content hashes, checkpoints results, and refreshes recurring-story clusters |
 | Deploy research dashboard | Every three hours and relevant pushes | Rebuilds marts from the public dataset and deploys GitHub Pages |
+| Deploy cited research Worker | Relevant Worker changes | Deploys the bounded DeepSeek synthesis endpoint to Cloudflare Workers |
 | CI | Pull requests and `main` | Runs Ruff, pytest, Astro checks/build, and Fenic's API checker |
 
 All Actions jobs use least-privilege repository permissions, locked dependencies, timeouts,
@@ -109,17 +110,23 @@ Parquet shards before upload. This keeps paid-call recovery granular without exh
 Face repository commit quota. A hard `$1.00` process ceiling, `$7.50` historical ceiling, and
 `$1.00` monthly incremental ceiling limit spend. Ambiguous model failures are recorded without
 automatic paid retries; a Hub commit-rate response waits for its quota window and retries once.
+Unpublished checkpoint rows count towards the same cumulative ledger, so an expired Hub token or
+failed upload cannot make a resumed run undercount prior paid work.
 
-The resulting Signals dashboard loads BGE Small in the browser by default, searches the archive by
-meaning, and shows computed rising themes, surface skews, story-form mix, and conservative
-recurring-story timelines. Explore uses the same compact int8 vector index for related coverage.
-Coverage is always visible because historical enrichment can take more than one run.
+The Overview now leads with computed theme momentum, front-page versus Most Read skews, and
+recurring stories. Signals loads BGE Small in the browser by default, searches the archive by
+meaning, and exposes the underlying trends, story-form mix, and recurring-story timelines. Explore
+uses the same compact int8 vector index for related coverage and paginates the story archive in
+finite 15-row pages. Coverage is always visible because historical enrichment can take more than
+one run.
 
 “Ask the archive” follows the same retrieval-then-synthesis pattern as the Fenic HN agent example.
 BGE retrieves the strongest matches locally in the browser, then a lightweight Cloudflare Worker
 sends at most ten validated BBC evidence rows to DeepSeek V4 Flash. Answers and findings cite the
-numbered results. The Worker keeps the key encrypted, caches identical answers, rate-limits clients,
-and bounds input and output. Source discovery still works if it is unavailable or over budget.
+numbered results. Fast mode disables thinking; optional Reasoned and Deep analysis modes enable
+bounded [DeepSeek thinking](https://api-docs.deepseek.com/guides/thinking_mode). Private reasoning is never stored or exposed. The Worker keeps the key
+encrypted, caches answers separately by reasoning depth, rate-limits clients, and bounds input and
+output. Source discovery still works if it is unavailable or over budget.
 
 Cloudflare's free Worker tier is a better fit than a hosted Python process because network wait does
 not count as CPU time and the service performs only one small external request. The durable spend

--- a/services/fenic/README.md
+++ b/services/fenic/README.md
@@ -48,7 +48,9 @@ The process calculates cost from DeepSeek's returned token counters and writes a
 the next wave starts. Publishing buffers those responses into immutable 256-row Parquet shards,
 reducing Hugging Face commits while retaining per-response paid-call recovery locally.
 The budget defaults to `$1.00` and the code rejects any higher process value. Persistent dataset
-rows enforce the separate `$7.50` backfill and `$1.00` monthly ledgers.
+rows and unpublished checkpoint rows jointly enforce the separate `$7.50` backfill and `$1.00`
+monthly ledgers. If a Hub upload fails, enrichment switches to local checkpointing and reports that
+publication was deferred instead of discarding completed paid work.
 
 ## Deployment
 

--- a/services/fenic/enrich.py
+++ b/services/fenic/enrich.py
@@ -7,7 +7,6 @@ import json
 import os
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from dataclasses import asdict, dataclass
-from datetime import datetime, timezone
 from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Any
@@ -24,6 +23,7 @@ from bbc_news_logger.deepseek import (
     DeepSeekClient,
     RunBudget,
     maximum_batch_request_cost_usd,
+    recorded_scope_spend,
 )
 from bbc_news_logger.semantics import (
     SIGNAL_PREFIX,
@@ -57,33 +57,11 @@ class EnrichmentReport:
     failures: int
     remaining: int
     stopped_for_budget: bool
+    publish_deferred: bool
 
 
 def _scope_spend(table: pa.Table | None, scope: str) -> Decimal:
-    if table is None:
-        return Decimal("0")
-    now = datetime.now(timezone.utc)
-    total = Decimal("0")
-    seen: set[tuple[str, str, str]] = set()
-    for row in table.to_pylist():
-        content_hash = str(row.get("content_sha256") or "")
-        identity = (
-            content_hash,
-            str(row.get("prompt_version") or ""),
-            str(row.get("deepseek_response_id") or ""),
-        )
-        if not content_hash or identity in seen:
-            continue
-        if row.get("model") != DEEPSEEK_MODEL:
-            continue
-        generated = row.get("generated_at")
-        if scope == "monthly" and (
-            generated is None or generated.year != now.year or generated.month != now.month
-        ):
-            continue
-        seen.add(identity)
-        total += Decimal(str(row.get("request_cost_usd") or 0))
-    return total
+    return recorded_scope_spend(table.to_pylist(), scope) if table is not None else Decimal("0")
 
 
 def _batches(rows: list[dict[str, Any]], size: int) -> list[list[dict[str, Any]]]:
@@ -150,11 +128,6 @@ def enrich(
     if article_table is None:
         raise FileNotFoundError(f"No article snapshots found in {dataset_id}")
 
-    prior_spend = _scope_spend(signal_table, scope)
-    scope_cap = MAX_BACKFILL_BUDGET_USD if scope == "backfill" else MAX_MONTHLY_BUDGET_USD
-    scope_remaining = max(Decimal("0"), scope_cap - prior_spend)
-    process_cap = min(maximum_cost_usd, scope_remaining)
-
     checkpoint = SemanticCheckpoint(checkpoint_path)
     try:
         remote_done = completed_hashes(
@@ -166,16 +139,41 @@ def enrich(
         local_rows = [
             row for row in checkpoint.rows() if str(row["content_sha256"]) not in remote_done
         ]
+        remote_spend = _scope_spend(signal_table, scope)
+        local_spend = recorded_scope_spend(local_rows, scope)
+        prior_spend = remote_spend + local_spend
+        scope_cap = (
+            MAX_BACKFILL_BUDGET_USD if scope == "backfill" else MAX_MONTHLY_BUDGET_USD
+        )
+        scope_remaining = max(Decimal("0"), scope_cap - prior_spend)
+        process_cap = min(maximum_cost_usd, scope_remaining)
         published_from_checkpoint = 0
+        publish_deferred = False
         if publish:
             for rows in _batches(local_rows, REMOTE_SIGNAL_SHARD_ROWS):
                 table = pa.Table.from_pylist(rows, schema=SIGNAL_SCHEMA)
-                publish_shard(
-                    table,
-                    prefix=SIGNAL_PREFIX,
-                    dataset_id=dataset_id,
-                    message=f"Checkpoint {len(rows)} DeepSeek story signals",
-                )
+                try:
+                    publish_shard(
+                        table,
+                        prefix=SIGNAL_PREFIX,
+                        dataset_id=dataset_id,
+                        message=f"Checkpoint {len(rows)} DeepSeek story signals",
+                    )
+                except Exception as exc:
+                    publish = False
+                    publish_deferred = True
+                    print(
+                        json.dumps(
+                            {
+                                "event": "deepseek_publish_deferred",
+                                "reason": str(exc)[:500],
+                                "rows_safe_in_checkpoint": len(local_rows),
+                            },
+                            sort_keys=True,
+                        ),
+                        flush=True,
+                    )
+                    break
                 published_from_checkpoint += len(rows)
                 remote_done.update(str(row["content_sha256"]) for row in rows)
 
@@ -267,20 +265,49 @@ def enrich(
                     )
             if publish and wave_rows:
                 rows_waiting_for_publish.extend(wave_rows)
+                try:
+                    _publish_ready_rows(
+                        rows_waiting_for_publish,
+                        dataset_id=dataset_id,
+                        rows_added=rows_added,
+                        force=False,
+                    )
+                except Exception as exc:
+                    publish = False
+                    publish_deferred = True
+                    print(
+                        json.dumps(
+                            {
+                                "event": "deepseek_publish_deferred",
+                                "reason": str(exc)[:500],
+                                "rows_safe_in_checkpoint": len(checkpoint.completed_hashes()),
+                            },
+                            sort_keys=True,
+                        ),
+                        flush=True,
+                    )
+
+        if publish:
+            try:
                 _publish_ready_rows(
                     rows_waiting_for_publish,
                     dataset_id=dataset_id,
                     rows_added=rows_added,
-                    force=False,
+                    force=True,
                 )
-
-        if publish:
-            _publish_ready_rows(
-                rows_waiting_for_publish,
-                dataset_id=dataset_id,
-                rows_added=rows_added,
-                force=True,
-            )
+            except Exception as exc:
+                publish_deferred = True
+                print(
+                    json.dumps(
+                        {
+                            "event": "deepseek_publish_deferred",
+                            "reason": str(exc)[:500],
+                            "rows_safe_in_checkpoint": len(checkpoint.completed_hashes()),
+                        },
+                        sort_keys=True,
+                    ),
+                    flush=True,
+                )
 
         return EnrichmentReport(
             model=DEEPSEEK_MODEL,
@@ -295,6 +322,7 @@ def enrich(
             failures=failure_count,
             remaining=max(0, len(candidates) - rows_added),
             stopped_for_budget=stopped_for_budget,
+            publish_deferred=publish_deferred,
         )
     finally:
         checkpoint.close()

--- a/services/fenic/serve.py
+++ b/services/fenic/serve.py
@@ -24,7 +24,7 @@ if not table_names:
 
 server = fc.create_mcp_server(
     session,
-    server_name="BBC News Research Lab",
+    server_name="BBC News Analyser",
     system_tools=fc.SystemToolConfig(
         table_names=table_names,
         tool_namespace="bbc_news",

--- a/src/bbc_news_logger/clustering.py
+++ b/src/bbc_news_logger/clustering.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import hashlib
 import os
 import re
-from collections import Counter
+from collections import Counter, defaultdict
 from datetime import timedelta
 from pathlib import Path
 from typing import Any
@@ -121,6 +121,8 @@ def cluster_events(
     window = timedelta(days=window_days)
     clusters: list[list[int]] = []
     story_cluster: dict[str, int] = {}
+    entity_clusters: dict[tuple[str, str], set[int]] = defaultdict(set)
+    label_token_clusters: dict[tuple[str, str], set[int]] = defaultdict(set)
     for index, content_hash in enumerate(hashes):
         article = article_rows[content_hash]
         fetched_at = article_rows[content_hash]["fetched_at"]
@@ -132,7 +134,14 @@ def cluster_events(
         current_signal = signal_rows[content_hash]
         best_cluster: int | None = None
         best_similarity = -1.0
-        for cluster_index, members in enumerate(clusters):
+        event_type = str(current_signal.get("event_type"))
+        candidates: set[int] = set()
+        for entity in _entities(current_signal):
+            candidates.update(entity_clusters[(event_type, entity)])
+        for token in _tokens(str(current_signal.get("event_label") or "")):
+            candidates.update(label_token_clusters[(event_type, token)])
+        for cluster_index in sorted(candidates):
+            members = clusters[cluster_index]
             anchor_index = members[0]
             latest_index = members[-1]
             if article_rows[hashes[latest_index]]["fetched_at"] < fetched_at - window:
@@ -151,6 +160,10 @@ def cluster_events(
         if best_cluster is None:
             best_cluster = len(clusters)
             clusters.append([index])
+            for entity in _entities(current_signal):
+                entity_clusters[(event_type, entity)].add(best_cluster)
+            for token in _tokens(str(current_signal.get("event_label") or "")):
+                label_token_clusters[(event_type, token)].add(best_cluster)
         else:
             clusters[best_cluster].append(index)
         story_cluster[story_id] = best_cluster

--- a/src/bbc_news_logger/deepseek.py
+++ b/src/bbc_news_logger/deepseek.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from collections.abc import Sequence
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Any
 
@@ -14,7 +15,7 @@ DEEPSEEK_API_URL = "https://api.deepseek.com/chat/completions"
 DEEPSEEK_MODEL = "deepseek-v4-flash"
 MAX_RUN_BUDGET_USD = Decimal("1.00")
 MAX_INPUT_BYTES = 32_000
-MAX_OUTPUT_TOKENS = 256
+MAX_OUTPUT_TOKENS = 320
 MAX_BATCH_SIZE = 8
 REQUEST_OVERHEAD_TOKEN_ALLOWANCE = 1_024
 PROMPT_VERSION = "2026-07-13-v1"
@@ -32,16 +33,28 @@ ALLOWED_TOPICS = {
     "science_and_environment",
     "technology",
     "health",
+    "education",
     "culture",
     "sport",
     "other",
+}
+TOPIC_ALIASES = {
+    "weather": "science_and_environment",
+    "environment": "science_and_environment",
+    "science": "science_and_environment",
+    "crime": "other",
+    "uk": "other",
+    "travel": "other",
+    "transport": "other",
+    "religion": "other",
+    "lifestyle": "other",
 }
 
 SYSTEM_PROMPT = """You label BBC News articles for longitudinal news analysis.
 Return one valid JSON object and no markdown. Use only facts in the supplied article.
 The object must contain:
-- topic: one of politics, world, business, science_and_environment, technology, health, culture,
-  sport, other
+- topic: one of politics, world, business, science_and_environment, technology, health, education,
+  culture, sport, other
 - themes: 1 to 5 short, reusable thematic labels, ordered most important first
 - summary: one neutral sentence
 - named_entities: up to 8 important people, organisations, or places
@@ -58,8 +71,8 @@ BATCH_SYSTEM_PROMPT = """You label BBC News articles for longitudinal news analy
 The user supplies a JSON object containing an articles array. Return one valid JSON object with an
 articles array in the same order and no markdown. Copy each article id exactly. For each article,
 use only facts in its supplied text and include:
-- topic: one of politics, world, business, science_and_environment, technology, health, culture,
-  sport, other
+- topic: one of politics, world, business, science_and_environment, technology, health, education,
+  culture, sport, other
 - themes: 1 to 5 short reusable labels
 - summary: one neutral sentence
 - named_entities: up to 8 important people, organisations, or places
@@ -153,6 +166,30 @@ class RunBudget:
             )
 
 
+def recorded_scope_spend(rows: Sequence[dict[str, Any]], scope: str) -> Decimal:
+    """Count unique persisted requests so local checkpoints remain inside the budget ledger."""
+
+    now = datetime.now(timezone.utc)
+    total = Decimal("0")
+    seen: set[tuple[str, str, str]] = set()
+    for row in rows:
+        content_hash = str(row.get("content_sha256") or "")
+        identity = (
+            content_hash,
+            str(row.get("prompt_version") or ""),
+            str(row.get("deepseek_response_id") or ""),
+        )
+        if not content_hash or identity in seen or row.get("model") != DEEPSEEK_MODEL:
+            continue
+        generated = row.get("generated_at")
+        if scope == "monthly" and (
+            generated is None or generated.year != now.year or generated.month != now.month
+        ):
+            continue
+        seen.add(identity)
+        total += Decimal(str(row.get("request_cost_usd") or 0))
+    return total
+
 def token_cost_usd(
     *, cache_hit_input_tokens: int, cache_miss_input_tokens: int, output_tokens: int
 ) -> Decimal:
@@ -238,6 +275,7 @@ def parse_signals(content: str) -> SemanticSignals:
         raise DeepSeekError("DeepSeek returned JSON that was not an object")
 
     topic = str(value.get("topic", "")).strip().lower()
+    topic = TOPIC_ALIASES.get(topic, topic)
     if topic not in ALLOWED_TOPICS:
         raise DeepSeekError(f"DeepSeek returned an unsupported topic: {topic!r}")
     summary = str(value.get("summary", "")).strip()

--- a/src/bbc_news_logger/marts.py
+++ b/src/bbc_news_logger/marts.py
@@ -272,9 +272,18 @@ def _semantic_findings(
         key=lambda row: abs(float(row["differencePercentagePoints"])), reverse=True
     )
     changes.sort(key=lambda row: float(row["changePercentagePoints"]), reverse=True)
+    prominent_recurring = sorted(
+        recurring,
+        key=lambda event: (
+            int(event["article_count"]),
+            int(event["version_count"]),
+            str(event["last_seen"]),
+        ),
+        reverse=True,
+    )
     returning = [
         {key: value for key, value in event.items() if key != "articles"}
-        for event in recurring[:8]
+        for event in prominent_recurring[:8]
     ]
     return {
         "window": {

--- a/tests/test_deepseek.py
+++ b/tests/test_deepseek.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 from decimal import Decimal
 
 import pytest
@@ -19,6 +20,7 @@ from bbc_news_logger.deepseek import (
     parse_signal_batch,
     parse_signals,
     parse_usage,
+    recorded_scope_spend,
     token_cost_usd,
     truncate_utf8,
 )
@@ -81,6 +83,20 @@ def test_run_budget_cannot_be_raised_above_one_dollar() -> None:
         budget.reserve(Decimal("0.02"))
 
 
+def test_persisted_checkpoint_spend_is_deduplicated_for_the_budget_ledger() -> None:
+    row = {
+        "content_sha256": "hash-a",
+        "model": DEEPSEEK_MODEL,
+        "prompt_version": "v1",
+        "deepseek_response_id": "response-a",
+        "generated_at": datetime.now(timezone.utc),
+        "request_cost_usd": 0.002,
+    }
+    second = {**row, "content_sha256": "hash-b", "deepseek_response_id": "response-b"}
+
+    assert recorded_scope_spend([row, dict(row), second], "backfill") == Decimal("0.004")
+
+
 def test_input_is_truncated_on_utf8_boundary() -> None:
     value = truncate_utf8("é" * MAX_INPUT_BYTES)
     assert len(value.encode("utf-8")) <= MAX_INPUT_BYTES
@@ -96,6 +112,33 @@ def test_signal_parser_rejects_uncontrolled_topics() -> None:
     payload["topic"] = "celebrity gossip"
     with pytest.raises(DeepSeekError, match="unsupported topic"):
         parse_signals(json.dumps(payload))
+
+
+def test_signal_parser_accepts_education_as_a_stable_topic() -> None:
+    payload = json.loads(signal_json())
+    payload["topic"] = "education"
+
+    assert parse_signals(json.dumps(payload)).topic == "education"
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("weather", "science_and_environment"),
+        ("environment", "science_and_environment"),
+        ("crime", "other"),
+        ("uk", "other"),
+        ("travel", "other"),
+        ("transport", "other"),
+        ("religion", "other"),
+        ("lifestyle", "other"),
+    ],
+)
+def test_signal_parser_normalizes_predictable_topic_aliases(raw: str, expected: str) -> None:
+    payload = json.loads(signal_json())
+    payload["topic"] = raw
+
+    assert parse_signals(json.dumps(payload)).topic == expected
 
 
 def test_usage_parser_accounts_for_cache_hits() -> None:

--- a/tests/test_marts.py
+++ b/tests/test_marts.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta, timezone
 
 import pyarrow as pa
 
-from bbc_news_logger.marts import build_marts
+from bbc_news_logger.marts import _semantic_findings, build_marts
 from bbc_news_logger.models import Observation
 from bbc_news_logger.semantics import (
     EMBEDDING_DIMENSIONS,
@@ -125,3 +125,40 @@ def test_build_marts_quantizes_aligned_browser_search_index(tmp_path) -> None:
     assert metadata["documents"][0]["story_id"] == observation.story_id
     assert metadata["documents"][0]["summary"] == signal["summary"]
     assert len((tmp_path / "semantic-vectors.i8").read_bytes()) == EMBEDDING_DIMENSIONS
+
+
+def test_findings_surface_the_most_substantial_recurring_stories() -> None:
+    fetched = datetime(2026, 7, 12, 10, tzinfo=timezone.utc)
+    recurring = [
+        {
+            "cluster_id": "recent-small",
+            "label": "Recent two-article event",
+            "event_type": "other",
+            "themes": [],
+            "first_seen": fetched.isoformat(),
+            "last_seen": fetched.isoformat(),
+            "article_count": 2,
+            "version_count": 2,
+            "articles": [],
+        },
+        {
+            "cluster_id": "older-large",
+            "label": "Persistent event",
+            "event_type": "other",
+            "themes": [],
+            "first_seen": (fetched - timedelta(days=10)).isoformat(),
+            "last_seen": (fetched - timedelta(days=1)).isoformat(),
+            "article_count": 8,
+            "version_count": 12,
+            "articles": [],
+        },
+    ]
+
+    findings = _semantic_findings(
+        {"hash": {"fetched_at": fetched, "story_id": "story"}},
+        {"hash": {"themes": ["example"], "story_form": "update"}},
+        [],
+        recurring,
+    )
+
+    assert findings["returningStories"][0]["cluster_id"] == "older-large"

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "bbc-news-research-lab",
+  "name": "bbc-news-analyser",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "bbc-news-research-lab",
+      "name": "bbc-news-analyser",
       "dependencies": {
         "@astrojs/check": "^0.9.6",
         "@huggingface/transformers": "^4.2.0",

--- a/web/package.json
+++ b/web/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "bbc-news-research-lab",
+  "name": "bbc-news-analyser",
   "private": true,
   "type": "module",
   "scripts": {

--- a/web/public/favicon.svg
+++ b/web/public/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="#182231"/>
+  <path d="M13 15h9v34h-9zm15 11h9v23h-9zm15-8h9v31h-9z" fill="#f7f8fb"/>
+  <path d="M13 39h9v10h-9zm15-13h9v23h-9zm15 8h9v15h-9z" fill="#49c5d5"/>
+  <path d="M10 49h45" stroke="#f3a342" stroke-width="3"/>
+</svg>

--- a/web/src/layouts/Layout.astro
+++ b/web/src/layouts/Layout.astro
@@ -18,19 +18,21 @@ const base = `${import.meta.env.BASE_URL.replace(/\/+$/, "")}/`;
     <meta name="viewport" content="width=device-width" />
     <meta name="description" content={description} />
     <meta name="theme-color" content="#f7f8fb" />
+    <meta name="application-name" content="BBC News Analyser" />
+    <link rel="icon" type="image/svg+xml" href={`${base}favicon.svg`} />
     <title>{title}</title>
   </head>
   <body>
     <a class="skip-link" href="#main">Skip to content</a>
     <header class="site-header">
-      <a class="wordmark" href={base} aria-label="BBC News Research Lab home">
+      <a class="wordmark" href={base} aria-label="BBC News Analyser home">
         <span class="wordmark-mark" aria-hidden="true">BN</span>
-        <span>News Surface Lab</span>
+        <span>BBC News Analyser</span>
       </a>
       <nav aria-label="Primary navigation">
         <a href={base} aria-current={current === "overview" ? "page" : undefined}>Overview</a>
         <a href={`${base}explore/`} aria-current={current === "explore" ? "page" : undefined}>Explore</a>
-        <a href={`${base}signals/`} aria-current={current === "signals" ? "page" : undefined}>Signals</a>
+        <a href={`${base}signals/`} aria-current={current === "signals" ? "page" : undefined}>Ask &amp; analyse</a>
         <a href={`${base}methodology/`} aria-current={current === "methodology" ? "page" : undefined}>Methodology</a>
       </nav>
       <a class="header-link" href="https://huggingface.co/datasets/AlastairH/bbc-news-logger">
@@ -42,7 +44,7 @@ const base = `${import.meta.env.BASE_URL.replace(/\/+$/, "")}/`;
     </main>
     <footer>
       <div>
-        <strong>BBC News Surface Observations</strong>
+        <strong>BBC News Analyser</strong>
         <p>An independent research project. Not affiliated with or endorsed by the BBC.</p>
       </div>
       <div class="footer-links">

--- a/web/src/pages/explore.astro
+++ b/web/src/pages/explore.astro
@@ -3,7 +3,7 @@ import Layout from "../layouts/Layout.astro";
 ---
 
 <Layout
-  title="Explore stories — BBC News Surface Lab"
+  title="Explore stories — BBC News Analyser"
   description="Search story histories and compare BBC News front-page and Most Read appearances."
   current="explore"
 >
@@ -11,9 +11,9 @@ import Layout from "../layouts/Layout.astro";
     <header class="page-intro">
       <div>
         <p class="eyebrow">Story-level explorer</p>
-        <h1>Trace a story across both surfaces.</h1>
+        <h1>Browse the evidence, without the endless scroll.</h1>
       </div>
-      <p>Search title text, narrow by observed surface, and select a story to inspect its rank history. All times are UTC.</p>
+      <p>Search title text, narrow by observed surface, and inspect fifteen stories at a time. Select one for its rank history, semantic summary, and related coverage. All times are UTC.</p>
     </header>
 
     <form class="toolbar" id="filters" role="search">
@@ -39,14 +39,25 @@ import Layout from "../layouts/Layout.astro";
       </div>
     </form>
 
-    <div class="explorer">
-      <div class="table-wrap">
-        <table>
-          <caption class="sr-only">Stories matching the selected filters</caption>
-          <thead><tr><th>Story</th><th>Surface</th><th>Best</th><th>Last seen</th></tr></thead>
-          <tbody id="story-rows"><tr><td class="loading" colspan="4">Loading story mart…</td></tr></tbody>
-        </table>
-      </div>
+    <div class="explorer" id="story-explorer">
+      <section class="story-list" aria-labelledby="story-list-heading">
+        <div class="table-meta">
+          <div><p class="eyebrow">Matching stories</p><h2 id="story-list-heading">Archive index</h2></div>
+          <p id="result-summary" aria-live="polite">Loading story mart…</p>
+        </div>
+        <div class="table-wrap">
+          <table>
+            <caption class="sr-only">Stories matching the selected filters</caption>
+            <thead><tr><th>Story</th><th>Surface</th><th>Best</th><th>Last seen</th></tr></thead>
+            <tbody id="story-rows"><tr><td class="loading" colspan="4">Loading story mart…</td></tr></tbody>
+          </table>
+        </div>
+        <nav class="pagination" aria-label="Story result pages">
+          <button class="button secondary" id="previous-page" type="button">← Previous</button>
+          <span id="page-status">Page —</span>
+          <button class="button secondary" id="next-page" type="button">Next →</button>
+        </nav>
+      </section>
       <aside class="detail" id="story-detail" aria-live="polite">
         <p class="eyebrow">Selected story</p>
         <h2>Choose a row to inspect its history.</h2>
@@ -99,6 +110,8 @@ import Layout from "../layouts/Layout.astro";
     let selectedId: string | null = null;
     let semanticIndexReady = false;
     let relatedRequestId = 0;
+    let currentPage = 0;
+    const pageSize = 15;
 
     const escape = (value: unknown): string => {
       const entities: Record<string, string> = { "&": "&amp;", "<": "&lt;", ">": "&gt;", "'": "&#39;", '"': "&quot;" };
@@ -135,12 +148,22 @@ import Layout from "../layouts/Layout.astro";
         if (order === "rank") return a.best_position - b.best_position;
         return String(b.last_seen).localeCompare(String(a.last_seen));
       });
-      return filtered.slice(0, 250);
+      return filtered;
     }
 
     function renderRows() {
       const tbody = element("#story-rows");
-      const rows = visibleStories();
+      const filtered = visibleStories();
+      const pageCount = Math.max(1, Math.ceil(filtered.length / pageSize));
+      currentPage = Math.min(currentPage, pageCount - 1);
+      const first = currentPage * pageSize;
+      const rows = filtered.slice(first, first + pageSize);
+      element("#result-summary").textContent = filtered.length ? `${(first + 1).toLocaleString("en-GB")}–${Math.min(first + pageSize, filtered.length).toLocaleString("en-GB")} of ${filtered.length.toLocaleString("en-GB")} stories` : "No matching stories";
+      element("#page-status").textContent = `Page ${(currentPage + 1).toLocaleString("en-GB")} of ${pageCount.toLocaleString("en-GB")}`;
+      const previous = document.querySelector<HTMLButtonElement>("#previous-page");
+      const next = document.querySelector<HTMLButtonElement>("#next-page");
+      if (previous) previous.disabled = currentPage === 0;
+      if (next) next.disabled = currentPage >= pageCount - 1 || !filtered.length;
       tbody.innerHTML = rows.length ? rows.map((story) => `
         <tr data-id="${story.story_id}" aria-selected="${story.story_id === selectedId}">
           <td><button type="button" data-id="${story.story_id}">${escape(story.title)}</button><span class="muted">${story.observation_count.toLocaleString("en-GB")} observations</span></td>
@@ -224,7 +247,13 @@ import Layout from "../layouts/Layout.astro";
       }
     });
 
-    element("#filters").addEventListener("input", renderRows);
+    element("#filters").addEventListener("input", () => { currentPage = 0; renderRows(); });
+    element("#previous-page").addEventListener("click", () => {
+      if (currentPage > 0) { currentPage -= 1; renderRows(); element("#story-list-heading").scrollIntoView(); }
+    });
+    element("#next-page").addEventListener("click", () => {
+      if ((currentPage + 1) * pageSize < visibleStories().length) { currentPage += 1; renderRows(); element("#story-list-heading").scrollIntoView(); }
+    });
     Promise.all([
       fetch(`${base}data/stories.json`).then((response) => response.json()),
       fetch(`${base}data/rank-series.json`).then((response) => response.json()),

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -5,19 +5,23 @@ const base = `${import.meta.env.BASE_URL.replace(/\/+$/, "")}/`;
 ---
 
 <Layout
-  title="BBC News Surface Lab — longitudinal news prominence"
-  description="Explore how stories move between the BBC News front page and Most Read list."
+  title="BBC News Analyser — longitudinal news prominence"
+  description="Analyse how BBC News stories, themes, and recurring events move between the front page and Most Read list."
   current="overview"
 >
   <div class="shell">
     <section class="hero">
       <div class="hero-copy">
-        <p class="eyebrow">Independent longitudinal dataset</p>
-        <h1>What rises, what stays, what gets read.</h1>
+        <p class="eyebrow">Independent longitudinal analysis</p>
+        <h1>See how the news agenda moves.</h1>
         <p>
-          Hourly observations of BBC News editorial prominence and audience attention,
-          structured for reproducible research rather than a passing feed.
+          Search years of BBC News coverage by meaning, follow recurring stories, and compare
+          what reaches the front page with what appears in Most Read.
         </p>
+        <div class="hero-actions">
+          <a class="button" href={`${base}signals/`}>Ask the archive <span aria-hidden="true">→</span></a>
+          <a class="button secondary" href={`${base}explore/`}>Browse stories</a>
+        </div>
       </div>
       <aside class="hero-note">
         <strong>Two surfaces, one timeline</strong>
@@ -53,6 +57,43 @@ const base = `${import.meta.env.BASE_URL.replace(/\/+$/, "")}/`;
   </section>
 
   <div class="shell">
+    <section class="section overview-findings" aria-labelledby="findings-heading">
+      <div class="section-head">
+        <div>
+          <p class="eyebrow">Latest computed findings</p>
+          <h2 id="findings-heading">What the labelled archive is showing</h2>
+        </div>
+        <p id="findings-window">Loading the latest comparable analysis window…</p>
+      </div>
+      <div class="overview-insights">
+        <article class="momentum-card">
+          <div class="insight-heading">
+            <span>Theme momentum</span>
+            <a href={`${base}signals/#trend-heading`}>Inspect trends →</a>
+          </div>
+          <div id="lead-theme" class="lead-finding"><p class="loading">Loading rising themes…</p></div>
+          <div id="theme-momentum" class="insight-list"></div>
+        </article>
+        <article class="surface-card">
+          <div class="insight-heading">
+            <span>Front page vs Most Read</span>
+            <a href={`${base}signals/#findings-heading`}>Compare surfaces →</a>
+          </div>
+          <p class="insight-explainer">Themes with the largest difference in their share of labelled coverage.</p>
+          <div id="surface-skews" class="insight-list"><p class="loading">Loading surface differences…</p></div>
+        </article>
+        <article class="returning-card">
+          <div class="insight-heading">
+            <span>Stories that return</span>
+            <a href={`${base}signals/#recurring-heading`}>Open timelines →</a>
+          </div>
+          <p class="insight-explainer">Events matched across distinct articles using labels, entities, and embeddings.</p>
+          <div id="returning-stories" class="returning-list"><p class="loading">Loading recurring stories…</p></div>
+        </article>
+      </div>
+      <p class="findings-caveat">These are model-assisted discovery signals, not claims about BBC intent or absolute audience size. Every finding can be opened against its underlying articles.</p>
+    </section>
+
     <section class="section" aria-labelledby="activity-heading">
       <div class="section-head">
         <div>
@@ -79,32 +120,6 @@ const base = `${import.meta.env.BASE_URL.replace(/\/+$/, "")}/`;
       </figure>
     </section>
 
-    <section class="section" aria-labelledby="questions-heading">
-      <div class="section-head">
-        <div>
-          <p class="eyebrow">Designed for inquiry</p>
-          <h2 id="questions-heading">Questions the record can support</h2>
-        </div>
-        <a class="button secondary" href={`${base}explore/`}>Open the explorer <span aria-hidden="true">→</span></a>
-      </div>
-      <div class="questions">
-        <article class="question">
-          <span class="number">01 / PROMINENCE</span>
-          <h3>How long does a story retain a visible position?</h3>
-          <p>Follow every observed rank from first appearance to last, without reducing a story to a daily snapshot.</p>
-        </article>
-        <article class="question">
-          <span class="number">02 / TRANSFER</span>
-          <h3>When does attention follow editorial placement?</h3>
-          <p>Compare each story’s first appearance across surfaces and inspect the lag in either direction.</p>
-        </article>
-        <article class="question">
-          <span class="number">03 / ABSENCE</span>
-          <h3>Which popular stories never appear in the recorded front-page set?</h3>
-          <p>Filter by surface and time window, while keeping the limits of the captured page regions explicit.</p>
-        </article>
-      </div>
-    </section>
   </div>
 
   <script>
@@ -121,6 +136,17 @@ const base = `${import.meta.env.BASE_URL.replace(/\/+$/, "")}/`;
       storyCount: number;
     }
 
+    interface ThemeChange { theme: string; recentCount: number; previousCount: number; changePercentagePoints: number }
+    interface SurfaceDifference { theme: string; differencePercentagePoints: number }
+    interface ReturningStory { cluster_id: string; label: string; article_count: number; last_seen: string }
+    interface Findings {
+      window: null | { recentStart: string; recentEnd: string; recentLabelledArticles: number; previousLabelledArticles: number };
+      risingThemes: ThemeChange[];
+      fallingThemes: ThemeChange[];
+      surfaceDifferences: SurfaceDifference[];
+      returningStories: ReturningStory[];
+    }
+
     const base = `${import.meta.env.BASE_URL.replace(/\/+$/, "")}/`;
     const number = new Intl.NumberFormat("en-GB");
     const shortDate = new Intl.DateTimeFormat("en-GB", { day: "2-digit", month: "short", year: "numeric", timeZone: "UTC" });
@@ -130,6 +156,32 @@ const base = `${import.meta.env.BASE_URL.replace(/\/+$/, "")}/`;
       if (!value) throw new Error(`Missing element: ${selector}`);
       return value;
     };
+
+    const escape = (value: unknown): string => {
+      const entities: Record<string, string> = { "&": "&amp;", "<": "&lt;", ">": "&gt;", "'": "&#39;", '"': "&quot;" };
+      return String(value).replace(/[&<>'"]/g, (character) => entities[character] ?? character);
+    };
+
+    function queryLink(theme: string): string {
+      return `${base}signals/?q=${encodeURIComponent(`How has coverage of ${theme} changed?`)}`;
+    }
+
+    function renderFindings(findings: Findings) {
+      if (!findings.window) return;
+      const { recentStart, recentEnd, recentLabelledArticles, previousLabelledArticles } = findings.window;
+      element("#findings-window").textContent = `${shortDate.format(new Date(recentStart))}–${shortDate.format(new Date(recentEnd))}, compared with the previous 14 days · ${number.format(recentLabelledArticles + previousLabelledArticles)} labelled article versions`;
+      const [lead, ...rising] = findings.risingThemes;
+      if (lead) {
+        element("#lead-theme").innerHTML = `<span class="lead-change">+${lead.changePercentagePoints.toFixed(2)}<small>pp</small></span><div><h3>${escape(lead.theme)}</h3><p>${number.format(lead.recentCount)} recent articles, up from ${number.format(lead.previousCount)} in the prior window.</p><a href="${queryLink(lead.theme)}">Ask about this theme →</a></div>`;
+      }
+      const momentum = [...rising.slice(0, 3), ...findings.fallingThemes.slice(0, 2)];
+      element("#theme-momentum").innerHTML = momentum.map((row) => `<a href="${queryLink(row.theme)}"><strong>${escape(row.theme)}</strong><span class="${row.changePercentagePoints >= 0 ? "up" : "down"}">${row.changePercentagePoints >= 0 ? "+" : ""}${row.changePercentagePoints.toFixed(2)} pp</span></a>`).join("");
+      element("#surface-skews").innerHTML = findings.surfaceDifferences.slice(0, 6).map((row) => {
+        const destination = row.differencePercentagePoints >= 0 ? "Most Read" : "Front page";
+        return `<a href="${queryLink(row.theme)}"><strong>${escape(row.theme)}</strong><span>${escape(destination)} · ${Math.abs(row.differencePercentagePoints).toFixed(2)} pp</span></a>`;
+      }).join("") || `<p class="loading">More labelled coverage is needed for this comparison.</p>`;
+      element("#returning-stories").innerHTML = findings.returningStories.slice(0, 4).map((story, index) => `<a href="${base}signals/#recurring-heading"><span>${String(index + 1).padStart(2, "0")}</span><strong>${escape(story.label)}</strong><small>${number.format(story.article_count)} articles · latest ${shortDate.format(new Date(story.last_seen))}</small></a>`).join("") || `<p class="loading">No conservative recurring-story clusters yet.</p>`;
+    }
 
     function drawChart(rows: DayRow[]) {
       const svg = document.querySelector("#daily-chart");
@@ -156,7 +208,8 @@ const base = `${import.meta.env.BASE_URL.replace(/\/+$/, "")}/`;
     Promise.all([
       fetch(`${base}data/manifest.json`).then((response) => response.json()),
       fetch(`${base}data/daily.json`).then((response) => response.json()),
-    ]).then(([manifest, daily]: [MartManifest, DayRow[]]) => {
+      fetch(`${base}data/semantic-findings.json`).then((response) => response.json()),
+    ]).then(([manifest, daily, findings]: [MartManifest, DayRow[], Findings]) => {
       element("#observation-count").textContent = number.format(manifest.observationCount);
       element("#story-count").textContent = number.format(manifest.storyCount);
       const latest = new Date(manifest.latestObservationAt);
@@ -165,6 +218,7 @@ const base = `${import.meta.env.BASE_URL.replace(/\/+$/, "")}/`;
       element("#collection-status").textContent = hours < 3 ? "Current" : "Delayed";
       element("#generated-at").textContent = `marts built ${shortDate.format(new Date(manifest.generatedAt))}`;
       drawChart(daily);
+      renderFindings(findings);
     }).catch(() => {
       element("#collection-status").textContent = "Unavailable";
       element("#generated-at").textContent = "static mart could not be loaded";

--- a/web/src/pages/methodology.astro
+++ b/web/src/pages/methodology.astro
@@ -3,7 +3,7 @@ import Layout from "../layouts/Layout.astro";
 ---
 
 <Layout
-  title="Methodology — BBC News Surface Lab"
+  title="Methodology — BBC News Analyser"
   description="Collection, storage, validation, and limitations for the BBC News Surface Observations dataset."
   current="methodology"
 >
@@ -13,7 +13,7 @@ import Layout from "../layouts/Layout.astro";
         <p class="eyebrow">Versioned methodology</p>
         <h1>A transparent collection, including its limits.</h1>
       </div>
-      <p>Schema version 1 · selector version 2026-07 · timestamps and daily partitions use UTC.</p>
+      <p>Dataset schema version 2 · selector version 2026-07 · timestamps and daily partitions use UTC.</p>
     </header>
 
     <div class="method-grid">
@@ -63,8 +63,9 @@ import Layout from "../layouts/Layout.astro";
           <p>Each distinct article content hash can receive two versioned derivatives. BGE Small produces a normalized 384-dimensional vector from the headline and opening article text. DeepSeek V4 Flash produces a validated topic, themes, story form, event type, event label, summary, and named entities.</p>
           <p>Paid requests contain no more than eight articles and run with a maximum concurrency of four. Results are committed to a synchronous local checkpoint before more paid work starts, then uploaded as content-addressed Parquet shards. The process enforces a $1 process ceiling, a $7.50 historical ceiling, and a $1 monthly incremental ceiling.</p>
           <p>The static site publishes one newest embedded version per story as a row-aligned, int8-quantised vector index. On the Signals page, BGE Small loads automatically through Transformers.js and embeds each query locally in the visitor's browser; query text is not sent to this project. The Explore page uses the same index to rank related coverage without loading the query model.</p>
+          <p>Overview findings are computed only from completed structured labels. Theme momentum compares theme share in adjacent 14-day windows, normalised by the number of labelled article versions in each window. Surface differences compare each theme's labelled share on the front page with its share in Most Read. Counts describe fetched article versions and captured positions, not readership.</p>
           <p>Recurring stories are joined conservatively. Versions with the same story identifier stay together; a different story must fall within 45 days, match the cluster anchor's event type, and combine strong vector similarity with shared named entities or event-label evidence. Anchor validation prevents a chain of individually similar articles from merging unrelated events. These outputs are discovery aids rather than editorial classifications or verified factual claims.</p>
-          <div class="notice"><strong>Hosted cited analysis.</strong> “Ask the archive” sends at most ten locally retrieved BBC evidence rows to a lightweight Cloudflare Worker for bounded DeepSeek synthesis. Its numbered claims link back to those results. Search, related coverage, trends, and findings remain local or static and usable when the optional service is unavailable or over budget.</div>
+          <div class="notice"><strong>Hosted cited analysis.</strong> “Ask the archive” sends at most ten locally retrieved BBC evidence rows to a lightweight Cloudflare Worker for bounded DeepSeek synthesis. Visitors can choose Fast, Reasoned, or Deep analysis; the latter two enable DeepSeek thinking with a bounded token allowance. Private reasoning is neither stored nor displayed—only the final cited answer is returned. Search, related coverage, trends, and findings remain local or static and usable when the optional service is unavailable or over budget.</div>
         </section>
 
         <section id="limitations">

--- a/web/src/pages/signals.astro
+++ b/web/src/pages/signals.astro
@@ -3,7 +3,7 @@ import Layout from "../layouts/Layout.astro";
 ---
 
 <Layout
-  title="Semantic search and signals | BBC News Surface Lab"
+  title="Ask the archive and analyse signals | BBC News Analyser"
   description="Search BBC News coverage by meaning and investigate recurring stories, themes, and editorial patterns."
   current="signals"
 >
@@ -61,6 +61,15 @@ import Layout from "../layouts/Layout.astro";
             <label for="semantic-form">Story form</label>
             <select id="semantic-form"><option value="all">All forms</option></select>
           </div>
+          <div class="field reasoning-field">
+            <label for="research-depth">Answer depth</label>
+            <select id="research-depth">
+              <option value="off">Fast</option>
+              <option value="high">Reasoned</option>
+              <option value="max">Deep analysis</option>
+            </select>
+            <small>Thinking uses more tokens; only the final cited answer is shown.</small>
+          </div>
         </div>
       </form>
       <div class="search-summary" id="search-summary">The index and query model are loading in the background.</div>
@@ -87,13 +96,13 @@ import Layout from "../layouts/Layout.astro";
       <div class="signals-heading">
         <div>
           <p class="context-label">Computed from labelled coverage</p>
-          <h2 id="findings-heading">What changed</h2>
+          <h2 id="findings-heading">What the archive is showing</h2>
           <p id="findings-window">Comparing adjacent 14-day windows and surface-level coverage shares.</p>
         </div>
       </div>
       <div class="findings-grid">
         <article class="finding-panel"><h3>Rising themes</h3><div id="rising-themes" class="finding-list"><p class="loading">Loading findings…</p></div></article>
-        <article class="finding-panel"><h3>Surface differences</h3><div id="surface-differences" class="finding-list"><p class="loading">Loading findings…</p></div></article>
+        <article class="finding-panel"><h3>Front page vs Most Read</h3><div id="surface-differences" class="finding-list"><p class="loading">Loading findings…</p></div></article>
         <article class="finding-panel"><h3>Story forms</h3><div id="story-forms" class="finding-list"><p class="loading">Loading findings…</p></div></article>
         <article class="finding-panel"><h3>Returning stories</h3><div id="returning-findings" class="finding-list"><p class="loading">Loading findings…</p></div></article>
       </div>
@@ -144,7 +153,7 @@ import Layout from "../layouts/Layout.astro";
     interface SearchDocument { story_id: string; title: string; url: string; fetched_at: string; surfaces: string[]; best_position: number | null; summary: string; topic: string; themes: string[]; story_form: string; event_type: string }
     interface SearchResult { document: SearchDocument; score: number }
     interface ResearchFinding { claim: string; sources: number[] }
-    interface ResearchResponse { answer: string; findings: ResearchFinding[]; limitations: string; model: string; cached: boolean; usage?: { promptTokens: number; completionTokens: number; costUsd: number } }
+    interface ResearchResponse { answer: string; findings: ResearchFinding[]; limitations: string; model: string; cached: boolean; reasoning?: string; usage?: { promptTokens: number; completionTokens: number; costUsd: number } }
 
     const base = `${import.meta.env.BASE_URL.replace(/\/+$/, "")}/`;
     const researchApi = import.meta.env.PUBLIC_RESEARCH_API_URL || "";
@@ -251,6 +260,17 @@ Every substantive claim must cite at least one supplied source. Do not invent so
       element("#research-key-status").textContent = browserKey() ? "A limited DeepSeek key is available for this tab." : "No browser key stored.";
     }
 
+    function reasoningDepth(): "off" | "high" | "max" {
+      const value = control("#research-depth").value;
+      return value === "high" || value === "max" ? value : "off";
+    }
+
+    function reasoningLabel(value: string): string {
+      if (value === "max") return "deep analysis";
+      if (value === "high") return "reasoned";
+      return "fast";
+    }
+
     async function requestResearch(query: string, evidence: Record<string, unknown>[], signal: AbortSignal): Promise<ResearchResponse> {
       const key = browserKey();
       if (!key) {
@@ -258,7 +278,7 @@ Every substantive claim must cite at least one supplied source. Do not invent so
         const response = await fetch(researchApi, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ query, evidence }),
+          body: JSON.stringify({ query, evidence, reasoning: reasoningDepth() }),
           signal,
         });
         const value = await response.json().catch(() => ({})) as ResearchResponse & { detail?: string };
@@ -266,6 +286,7 @@ Every substantive claim must cite at least one supplied source. Do not invent so
         return value;
       }
 
+      const reasoning = reasoningDepth();
       const response = await fetch("https://api.deepseek.com/chat/completions", {
         method: "POST",
         headers: { "Authorization": `Bearer ${key}`, "Content-Type": "application/json" },
@@ -275,8 +296,11 @@ Every substantive claim must cite at least one supplied source. Do not invent so
             { role: "system", content: directSystemPrompt },
             { role: "user", content: JSON.stringify({ question: query.slice(0, 400), evidence: evidence.slice(0, 10) }) },
           ],
-          response_format: { type: "json_object" }, thinking: { type: "disabled" },
-          max_tokens: 900, stream: false,
+          response_format: { type: "json_object" },
+          thinking: { type: reasoning === "off" ? "disabled" : "enabled" },
+          ...(reasoning === "off" ? {} : { reasoning_effort: reasoning }),
+          max_tokens: reasoning === "max" ? 5000 : reasoning === "high" ? 2500 : 900,
+          stream: false,
         }),
         signal,
       });
@@ -293,7 +317,7 @@ Every substantive claim must cite at least one supplied source. Do not invent so
       const cacheMiss = Number(usage.prompt_cache_miss_tokens ?? Math.max(0, Number(usage.prompt_tokens ?? 0) - cacheHit));
       return {
         answer: String(content.answer), findings, limitations: String(content.limitations ?? ""),
-        model: "deepseek-v4-flash · your key", cached: false,
+        model: "deepseek-v4-flash · your key", cached: false, reasoning,
         usage: {
           promptTokens: Number(usage.prompt_tokens ?? 0), completionTokens: Number(usage.completion_tokens ?? 0),
           costUsd: (cacheHit * .0028 + cacheMiss * .14 + Number(usage.completion_tokens ?? 0) * .28) / 1_000_000,
@@ -306,7 +330,8 @@ Every substantive claim must cite at least one supplied source. Do not invent so
       const panel = element("#research-answer");
       if (!query || !lastSearchResults.length) return;
       panel.hidden = false;
-      panel.innerHTML = `<p class="research-state">DeepSeek is reading ${Math.min(10, lastSearchResults.length)} retrieved sources. A sleeping free-CPU Space can take up to a minute to wake…</p>`;
+      const depth = reasoningDepth();
+      panel.innerHTML = `<p class="research-state">DeepSeek is reading ${Math.min(10, lastSearchResults.length)} retrieved sources in ${reasoningLabel(depth)} mode…</p>`;
       const evidence = lastSearchResults.slice(0, 10).map(({ document, score }) => ({
         title: document.title, url: document.url, date: document.fetched_at,
         summary: document.summary, topic: document.topic, themes: document.themes,
@@ -318,9 +343,9 @@ Every substantive claim must cite at least one supplied source. Do not invent so
         const value = await requestResearch(query, evidence, controller.signal);
         const findings = value.findings?.length ? `<ol class="research-findings">${value.findings.map((finding) => `<li><span>${escape(finding.claim)}</span><span class="research-citations">${sourceLinks(finding.sources)}</span></li>`).join("")}</ol>` : "";
         const cost = value.usage?.costUsd ? ` · $${value.usage.costUsd.toFixed(5)}` : "";
-        panel.innerHTML = `<div class="research-heading"><div><p class="context-label">Cited synthesis</p><h3>Answer from the retrieved archive</h3></div><span>${escape(value.model)}${value.cached ? " · cached" : cost}</span></div><p class="research-copy">${citedText(value.answer)}</p>${findings}${value.limitations ? `<p class="research-limit"><strong>Limits:</strong> ${escape(value.limitations)}</p>` : ""}<p class="research-disclaimer">Generated analysis can be wrong. Check the numbered BBC evidence below.</p>`;
+        panel.innerHTML = `<div class="research-heading"><div><p class="context-label">Cited synthesis</p><h3>Answer from the retrieved archive</h3></div><span>${escape(value.model)} · ${reasoningLabel(value.reasoning ?? depth)}${value.cached ? " · cached" : cost}</span></div><p class="research-copy">${citedText(value.answer)}</p>${findings}${value.limitations ? `<p class="research-limit"><strong>Limits:</strong> ${escape(value.limitations)}</p>` : ""}<p class="research-disclaimer">Generated analysis can be wrong. Check the numbered BBC evidence below. Private model reasoning is neither stored nor displayed.</p>`;
       } catch (error) {
-        const message = error instanceof DOMException && error.name === "AbortError" ? "The free-CPU research service did not wake in time." : error instanceof Error ? error.message : "The cited answer is temporarily unavailable.";
+        const message = error instanceof DOMException && error.name === "AbortError" ? "The research service did not answer in time." : error instanceof Error ? error.message : "The cited answer is temporarily unavailable.";
         panel.innerHTML = `<div class="research-heading"><div><p class="context-label">Local results still available</p><h3>The cited answer could not be generated</h3></div></div><p class="research-copy">${escape(message)}</p><p class="research-limit">Open <strong>DeepSeek access</strong> above to use a limited key directly from this tab, or try the shared service again.</p><button class="button secondary" id="retry-research" type="button">Try the synthesis again</button>`;
         document.querySelector<HTMLButtonElement>("#retry-research")?.addEventListener("click", () => void askArchive());
       } finally {

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -80,6 +80,7 @@
   .shell { width: min(100% - 2rem, var(--measure)); margin-inline: auto; }
   .hero { display: grid; grid-template-columns: 1.5fr .5fr; gap: 3rem; padding: clamp(4.5rem, 10vw, 9rem) 0 4rem; }
   .hero-copy > p:not(.eyebrow) { margin-top: 1.7rem; max-width: 53ch; font-size: clamp(1.05rem, 2vw, 1.35rem); color: var(--muted); }
+  .hero-actions { display: flex; flex-wrap: wrap; gap: .65rem; margin-top: 1.7rem; }
   .hero-note { align-self: end; border-top: 1px solid var(--line-strong); padding-top: 1rem; color: var(--muted); font-size: .83rem; }
   .hero-note strong { display: block; color: var(--ink); margin-bottom: .35rem; }
   .status-strip { border-block: 1px solid var(--line-strong); }
@@ -102,6 +103,34 @@
   .plot .read { fill: none; stroke: oklch(72% .13 235); stroke-width: 2.3; }
   .legend { display: flex; gap: 1.2rem; color: var(--dark-muted); font-size: .75rem; }
   .legend span::before { content: ""; display: inline-block; width: .7rem; height: .7rem; margin-right: .4rem; background: var(--legend); }
+  .overview-findings { padding-bottom: 2rem; }
+  .overview-insights { display: grid; grid-template-columns: minmax(0, 1.25fr) minmax(17rem, .8fr) minmax(17rem, .8fr); border: 1px solid var(--line-strong); background: var(--paper-strong); }
+  .overview-insights > article { min-width: 0; padding: clamp(1.1rem, 2.5vw, 1.7rem); border-right: 1px solid var(--line); }
+  .overview-insights > article:last-child { border-right: 0; }
+  .momentum-card { background: var(--dark); color: white; }
+  .insight-heading { display: flex; justify-content: space-between; gap: 1rem; padding-bottom: .8rem; border-bottom: 1px solid var(--line); color: var(--muted); font: .68rem var(--mono); letter-spacing: .05em; text-transform: uppercase; }
+  .momentum-card .insight-heading { border-color: var(--dark-line); color: var(--dark-muted); }
+  .insight-heading a { color: inherit; text-transform: none; letter-spacing: 0; }
+  .lead-finding { display: grid; grid-template-columns: auto 1fr; gap: 1.2rem; align-items: center; padding: 1.5rem 0 1rem; }
+  .lead-change { color: var(--cyan); font: 2.8rem var(--mono); letter-spacing: -.08em; }
+  .lead-change small { margin-left: .2rem; font-size: .8rem; letter-spacing: 0; }
+  .lead-finding h3 { font-size: 1.55rem; }
+  .lead-finding p { margin-top: .4rem; color: var(--dark-muted); font-size: .78rem; }
+  .lead-finding a { display: inline-block; margin-top: .65rem; color: var(--cyan); font-size: .72rem; }
+  .insight-explainer { margin: .85rem 0 .35rem; color: var(--muted); font-size: .76rem; }
+  .insight-list { display: grid; }
+  .insight-list > a { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: .8rem; padding: .7rem 0; border-top: 1px solid var(--line); text-decoration: none; font-size: .78rem; }
+  .momentum-card .insight-list > a { border-color: var(--dark-line); }
+  .insight-list span { color: var(--muted); font: .67rem var(--mono); }
+  .momentum-card .insight-list span { color: var(--dark-muted); }
+  .momentum-card .insight-list .up { color: var(--cyan); }
+  .momentum-card .insight-list .down { color: oklch(73% .16 50); }
+  .returning-list { display: grid; margin-top: .35rem; }
+  .returning-list a { display: grid; grid-template-columns: 2rem minmax(0, 1fr); gap: .1rem .6rem; padding: .75rem 0; border-top: 1px solid var(--line); text-decoration: none; }
+  .returning-list a > span { grid-row: 1 / 3; color: var(--signal); font: .68rem var(--mono); }
+  .returning-list strong { font-size: .8rem; line-height: 1.25; }
+  .returning-list small { color: var(--muted); font-size: .67rem; }
+  .findings-caveat { margin-top: .9rem; color: var(--muted); font-size: .72rem; }
   .questions { display: grid; grid-template-columns: repeat(3, 1fr); border-top: 1px solid var(--line-strong); }
   .question { min-height: 13rem; padding: 1.4rem 1.4rem 1.4rem 0; border-right: 1px solid var(--line); }
   .question:not(:first-child) { padding-left: 1.4rem; }
@@ -119,6 +148,13 @@
   .field label { font: .64rem var(--mono); letter-spacing: .08em; text-transform: uppercase; color: var(--muted); }
   input, select { min-height: 2.7rem; border: 1px solid var(--line-strong); border-radius: 8px; background: var(--paper-strong); color: var(--ink); padding: .55rem .7rem; }
   .explorer { display: grid; grid-template-columns: minmax(0, 1.3fr) minmax(19rem, .7fr); gap: 1rem; padding: 1rem 0 6rem; align-items: start; }
+  .story-list { min-width: 0; }
+  .table-meta { display: flex; justify-content: space-between; gap: 1rem; align-items: end; padding: .75rem 0; }
+  .table-meta h2 { margin-top: .15rem; font-size: 1.35rem; }
+  .table-meta > p { color: var(--muted); font: .7rem var(--mono); }
+  .pagination { display: grid; grid-template-columns: auto 1fr auto; gap: .7rem; align-items: center; padding-top: .75rem; }
+  .pagination span { justify-self: center; color: var(--muted); font: .7rem var(--mono); }
+  .pagination button:disabled { opacity: .38; cursor: not-allowed; }
   .table-wrap { overflow: auto; border: 1px solid var(--line-strong); background: var(--paper-strong); }
   table { width: 100%; border-collapse: collapse; font-size: .83rem; }
   th { text-align: left; color: var(--muted); padding: .75rem; border-bottom: 1px solid var(--line-strong); white-space: nowrap; }
@@ -175,7 +211,8 @@
   .semantic-query progress::-webkit-progress-bar { background: var(--line); }
   .semantic-query progress::-webkit-progress-value { background: var(--cyan); }
   .semantic-query progress::-moz-progress-bar { background: var(--cyan); }
-  .semantic-filters { display: grid; grid-template-columns: repeat(3, minmax(8rem, 1fr)); gap: .6rem; }
+  .semantic-filters { display: grid; grid-template-columns: repeat(2, minmax(8rem, 1fr)); gap: .6rem; }
+  .reasoning-field small { max-width: 15rem; color: var(--muted); font-size: .63rem; line-height: 1.25; }
   .search-summary { padding: .8rem 0; color: var(--muted); font: .72rem var(--mono); border-bottom: 1px solid var(--line-strong); }
   .research-access { border-bottom: 1px solid var(--line-strong); background: var(--paper-strong); }
   .research-access summary { padding: .7rem 1rem; color: var(--signal); font-size: .75rem; font-weight: 650; cursor: pointer; }
@@ -288,10 +325,14 @@
 
 @media (max-width: 760px) {
   .site-header { grid-template-columns: 1fr auto; min-height: 4.3rem; }
-  .site-header nav { grid-column: 1 / -1; order: 3; border-top: 1px solid var(--line); padding: .65rem 0; justify-content: space-between; }
+  .site-header nav { grid-column: 1 / -1; order: 3; gap: .75rem; overflow-x: auto; border-top: 1px solid var(--line); padding: .65rem 0; justify-content: space-between; }
+  .site-header nav a { flex: none; font-size: .8rem; }
   .header-link { display: none; }
   .hero, .page-intro, .section-head, .method-grid { grid-template-columns: 1fr; }
   .hero { gap: 2rem; }
+  .overview-insights { grid-template-columns: 1fr; }
+  .overview-insights > article { border-right: 0; border-bottom: 1px solid var(--line); }
+  .overview-insights > article:last-child { border-bottom: 0; }
   .status-grid { grid-template-columns: 1fr 1fr; }
   .metric:nth-child(2) { border-right: 0; }
   .metric:nth-child(-n+2) { border-bottom: 1px solid var(--line); }
@@ -332,6 +373,8 @@
   .search-input-row, .semantic-filters, .findings-grid { grid-template-columns: 1fr; }
   .search-actions { display: grid; grid-template-columns: 1fr 1fr; }
   .research-key-row { grid-template-columns: 1fr; }
+  .lead-finding { grid-template-columns: 1fr; }
+  .pagination .button { padding-inline: .6rem; }
   .research-heading, .research-findings li { grid-template-columns: 1fr; display: grid; }
   .semantic-filters .field:last-child, .evidence-link { grid-column: auto; }
   .semantic-result { grid-template-columns: 1fr; }

--- a/workers/research/src/core.mjs
+++ b/workers/research/src/core.mjs
@@ -1,6 +1,6 @@
 const MODEL = "deepseek-v4-flash";
 const MAX_EVIDENCE = 10;
-const MAX_OUTPUT_TOKENS = 900;
+const OUTPUT_TOKENS = { off: 900, high: 2500, max: 5000 };
 const INPUT_CACHE_HIT_PRICE = 0.0028;
 const INPUT_CACHE_MISS_PRICE = 0.14;
 const OUTPUT_PRICE = 0.28;
@@ -57,24 +57,28 @@ export function normalizeRequest(body) {
     });
   }
   if (!evidence.length) throw new InputError("No valid BBC evidence was supplied.");
-  return { query, evidence };
+  const reasoning = ["off", "high", "max"].includes(body?.reasoning) ? body.reasoning : "off";
+  return { query, evidence, reasoning };
 }
 
-export function deepSeekRequest(query, evidence) {
-  return {
+export function deepSeekRequest(query, evidence, reasoning = "off") {
+  const depth = ["off", "high", "max"].includes(reasoning) ? reasoning : "off";
+  const request = {
     model: MODEL,
     messages: [
       { role: "system", content: SYSTEM_PROMPT },
       { role: "user", content: JSON.stringify({ question: query, evidence }) },
     ],
     response_format: { type: "json_object" },
-    thinking: { type: "disabled" },
-    max_tokens: MAX_OUTPUT_TOKENS,
+    thinking: { type: depth === "off" ? "disabled" : "enabled" },
+    max_tokens: OUTPUT_TOKENS[depth],
     stream: false,
   };
+  if (depth !== "off") request.reasoning_effort = depth;
+  return request;
 }
 
-export function parseCompletion(payload, evidenceCount) {
+export function parseCompletion(payload, evidenceCount, reasoning = "off") {
   let content;
   try {
     content = JSON.parse(String(payload?.choices?.[0]?.message?.content ?? "{}"));
@@ -103,6 +107,7 @@ export function parseCompletion(payload, evidenceCount) {
     findings,
     limitations: compact(content?.limitations, 1500),
     model: MODEL,
+    reasoning,
     usage: {
       promptTokens,
       completionTokens,

--- a/workers/research/src/index.mjs
+++ b/workers/research/src/index.mjs
@@ -49,7 +49,7 @@ export default {
       return new Response(null, { status: ALLOWED_ORIGINS.has(origin) ? 204 : 403, headers: headers(origin) });
     }
     if (request.method === "GET" && url.pathname === "/api/health") {
-      return json({ status: "ok", model: "deepseek-v4-flash", runtime: "cloudflare-workers" }, 200, origin);
+      return json({ status: "ok", model: "deepseek-v4-flash", runtime: "cloudflare-workers", reasoningModes: ["off", "high", "max"] }, 200, origin);
     }
     if (request.method !== "POST" || url.pathname !== "/api/research") {
       return json({ detail: "Not found." }, 404, origin);
@@ -81,11 +81,11 @@ export default {
       provider = await fetch("https://api.deepseek.com/chat/completions", {
         method: "POST",
         headers: { "Authorization": `Bearer ${env.DEEPSEEK_API_KEY}`, "Content-Type": "application/json" },
-        body: JSON.stringify(deepSeekRequest(normalized.query, normalized.evidence)),
+        body: JSON.stringify(deepSeekRequest(normalized.query, normalized.evidence, normalized.reasoning)),
       });
       const payload = await provider.json();
       if (!provider.ok) throw new Error(String(payload?.error?.message ?? `DeepSeek returned ${provider.status}`));
-      const answer = parseCompletion(payload, normalized.evidence.length);
+      const answer = parseCompletion(payload, normalized.evidence.length, normalized.reasoning);
       const cacheResponse = new Response(JSON.stringify(answer), {
         headers: { "Content-Type": "application/json", "Cache-Control": "public, max-age=86400" },
       });

--- a/workers/research/test/core.test.mjs
+++ b/workers/research/test/core.test.mjs
@@ -18,17 +18,28 @@ test("normalization accepts only bounded unique BBC evidence", () => {
   const value = normalizeRequest({ query: "What changed?", evidence: Array(20).fill(row) });
   assert.equal(value.evidence.length, 1);
   assert.equal(value.evidence[0].id, 1);
+  assert.equal(value.reasoning, "off");
   assert.throws(
     () => normalizeRequest({ query: "What changed?", evidence: [{ ...row, url: "https://example.com" }] }),
     InputError,
   );
 });
 
-test("DeepSeek request is JSON, non-thinking, and output-bounded", () => {
+test("DeepSeek request defaults to bounded non-thinking mode", () => {
   const body = deepSeekRequest("What changed?", [{ ...row, id: 1 }]);
   assert.equal(body.model, "deepseek-v4-flash");
   assert.deepEqual(body.thinking, { type: "disabled" });
   assert.equal(body.max_tokens, 900);
+});
+
+test("DeepSeek request supports bounded high and maximum reasoning", () => {
+  const high = deepSeekRequest("What changed?", [{ ...row, id: 1 }], "high");
+  assert.deepEqual(high.thinking, { type: "enabled" });
+  assert.equal(high.reasoning_effort, "high");
+  assert.equal(high.max_tokens, 2500);
+  const maximum = deepSeekRequest("What changed?", [{ ...row, id: 1 }], "max");
+  assert.equal(maximum.reasoning_effort, "max");
+  assert.equal(maximum.max_tokens, 5000);
 });
 
 test("completion parsing removes invented citations and calculates cost", () => {


### PR DESCRIPTION
## Summary
- redesign Overview and paginate Explore around trends, themes, surface skews, and recurring stories
- add bounded DeepSeek reasoning modes to Ask the Archive and refresh BBC News Analyser branding/docs/favicon
- complete and harden semantic labelling, checkpoint publication, and efficient recurring-story clustering

## Data publication
- 17,462 / 17,462 article versions labelled (100% coverage)
- 14,919 semantic search documents
- 3,221 recurring clusters published upstream

## Verification
- 37 Python tests
- Ruff and git diff checks
- 4 Cloudflare Worker tests
- Astro production build: 0 errors/warnings; 4 routes and 9 data paths verified