### PR TITLE
Compact Hugging Face dataset reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ uv run bbc-news scrape --upload
 
 # Build the JSON marts used by the static dashboard
 uv run bbc-news build-marts --output web/public/data
+
+# Periodically fold append-only shards into four compact cold-start bases
+uv run bbc-news compact-dataset --publish
 ```
 
 ## Data contract
@@ -73,6 +76,11 @@ The public dataset has three configurations:
 Stable `story_id` values derive from normalized canonical URLs. Each Parquet file embeds a schema
 version. Publication is an idempotent upsert on the record key, so rerunning a workflow cannot
 duplicate a batch.
+
+The compact bases are an LSM-style storage layer: scheduled jobs continue to append small
+incremental shards, while an occasional `compact-dataset --publish` atomically folds them into the
+base files. Dashboard and Fenic readers load both layers, reducing a clean deployment from more
+than a thousand HTTP object fetches to five without changing the tables or incremental workflow.
 
 The dataset cards and the dashboard's Methodology page document repaired legacy fields,
 reconstructed front-page position, selector risk, and interpretive limits.

--- a/services/fenic/bootstrap.py
+++ b/services/fenic/bootstrap.py
@@ -10,6 +10,8 @@ from pathlib import Path
 import fenic as fc
 from huggingface_hub import snapshot_download
 
+from bbc_news_logger.compaction import download_patterns, parquet_files
+
 DATASET_ID = os.getenv("BBC_NEWS_DATASET", "AlastairH/bbc-news-logger")
 APP_NAME = os.getenv("FENIC_APP_NAME", "bbc_news_research_lab")
 DB_PATH = Path(os.getenv("FENIC_DB_PATH", ".fenic"))
@@ -56,12 +58,12 @@ def dataset_paths(prefix: str) -> list[str]:
         snapshot_download(
             repo_id=DATASET_ID,
             repo_type="dataset",
-            allow_patterns=f"{prefix}**/*.parquet",
+            allow_patterns=download_patterns([prefix.rstrip("/")]),
             token=os.getenv("HF_TOKEN"),
             max_workers=8,
         )
     )
-    return [str(path) for path in sorted((snapshot / prefix).rglob("*.parquet"))]
+    return [str(path) for path in parquet_files(snapshot, prefix.rstrip("/"))]
 
 
 def bootstrap(table_names: Iterable[str] | None = None) -> dict[str, int]:

--- a/src/bbc_news_logger/cli.py
+++ b/src/bbc_news_logger/cli.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from huggingface_hub import HfApi
 
 from .articles import ArticleTarget, fetch_articles
+from .compaction import compact_remote_dataset, temporary_output
 from .config import DEFAULT_DATASET_ID, DEFAULT_RAW_DATASET_ID
 from .marts import build_remote_marts
 from .migration import build_migration
@@ -113,6 +114,16 @@ def command_build_marts(args: argparse.Namespace) -> None:
     print(json.dumps(manifest, sort_keys=True))
 
 
+def command_compact(args: argparse.Namespace) -> None:
+    output = Path(args.output) if args.output else temporary_output()
+    report = compact_remote_dataset(
+        output,
+        dataset_id=args.dataset,
+        publish=args.publish,
+    )
+    print(json.dumps(report, sort_keys=True))
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="bbc-news")
     parser.set_defaults(func=lambda _: parser.print_help())
@@ -150,6 +161,14 @@ def build_parser() -> argparse.ArgumentParser:
     marts.add_argument("--output", default="web/public/data")
     marts.add_argument("--dataset", default=DEFAULT_DATASET_ID)
     marts.set_defaults(func=command_build_marts)
+
+    compact = subcommands.add_parser(
+        "compact-dataset", help="Compact append-only Hugging Face Parquet shards"
+    )
+    compact.add_argument("--output")
+    compact.add_argument("--publish", action="store_true")
+    compact.add_argument("--dataset", default=DEFAULT_DATASET_ID)
+    compact.set_defaults(func=command_compact)
     return parser
 
 

--- a/src/bbc_news_logger/compaction.py
+++ b/src/bbc_news_logger/compaction.py
@@ -1,0 +1,126 @@
+"""Compact append-only Hugging Face Parquet shards into fast cold-start bases."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+from huggingface_hub import CommitOperationAdd, CommitOperationDelete, HfApi, snapshot_download
+
+from .config import DEFAULT_DATASET_ID
+
+COMPACTABLE_PREFIXES = (
+    "data/observations",
+    "data/article_snapshots",
+    "semantic/signals",
+    "semantic/embeddings",
+)
+LATEST_BY_HASH = {
+    "semantic/signals": "generated_at",
+    "semantic/embeddings": "generated_at",
+}
+
+
+def compact_path(prefix: str) -> str:
+    """Return the canonical base path for a dataset family."""
+
+    return f"compacted/{prefix.replace('/', '--')}.parquet"
+
+
+def download_patterns(prefixes: Sequence[str]) -> list[str]:
+    """Include compact bases and any incremental shards written after compaction."""
+
+    return [
+        pattern
+        for prefix in prefixes
+        for pattern in (compact_path(prefix), f"{prefix}/*.parquet", f"{prefix}/**/*.parquet")
+    ]
+
+
+def parquet_files(snapshot: Path, prefix: str) -> list[Path]:
+    files = sorted((snapshot / prefix).rglob("*.parquet"))
+    base = snapshot / compact_path(prefix)
+    return ([base] if base.exists() else []) + files
+
+
+def _latest_by_hash(table: pa.Table, timestamp: str) -> pa.Table:
+    rows: dict[str, dict[str, Any]] = {}
+    for row in table.to_pylist():
+        content_hash = str(row.get("content_sha256") or "")
+        existing = rows.get(content_hash)
+        if content_hash and (existing is None or row[timestamp] > existing[timestamp]):
+            rows[content_hash] = row
+    return pa.Table.from_pylist(list(rows.values()), schema=table.schema)
+
+
+def compact_table(prefix: str, files: Sequence[Path]) -> pa.Table:
+    if not files:
+        raise FileNotFoundError(f"No Parquet shards found for {prefix}")
+    table = pa.concat_tables(
+        [pq.ParquetFile(path).read() for path in files], promote_options="default"
+    )
+    timestamp = LATEST_BY_HASH.get(prefix)
+    return _latest_by_hash(table, timestamp) if timestamp else table
+
+
+def compact_remote_dataset(
+    output: Path,
+    *,
+    dataset_id: str = DEFAULT_DATASET_ID,
+    token: str | None = None,
+    publish: bool = False,
+) -> dict[str, dict[str, int]]:
+    """Build compact bases and optionally replace the source shards atomically."""
+
+    token = token or os.getenv("HF_TOKEN")
+    snapshot = Path(
+        snapshot_download(
+            repo_id=dataset_id,
+            repo_type="dataset",
+            allow_patterns=download_patterns(COMPACTABLE_PREFIXES),
+            token=token,
+            max_workers=8,
+        )
+    )
+    output.mkdir(parents=True, exist_ok=True)
+    report: dict[str, dict[str, int]] = {}
+    local_files: dict[str, Path] = {}
+    for prefix in COMPACTABLE_PREFIXES:
+        files = parquet_files(snapshot, prefix)
+        table = compact_table(prefix, files)
+        local = output / Path(compact_path(prefix)).name
+        pq.write_table(table, local, compression="zstd")
+        local_files[prefix] = local
+        report[prefix] = {
+            "source_files": len(files),
+            "rows": table.num_rows,
+            "bytes": local.stat().st_size,
+        }
+
+    if publish:
+        operations = [
+            CommitOperationAdd(
+                path_in_repo=compact_path(prefix), path_or_fileobj=local_files[prefix]
+            )
+            for prefix in COMPACTABLE_PREFIXES
+        ]
+        operations.extend(
+            CommitOperationDelete(path_in_repo=prefix, is_folder=True)
+            for prefix in COMPACTABLE_PREFIXES
+        )
+        HfApi(token=token).create_commit(
+            repo_id=dataset_id,
+            repo_type="dataset",
+            operations=operations,
+            commit_message="Compact dashboard dataset shards",
+        )
+    return report
+
+
+def temporary_output() -> Path:
+    return Path(tempfile.mkdtemp(prefix="bbc-news-compaction-"))

--- a/src/bbc_news_logger/marts.py
+++ b/src/bbc_news_logger/marts.py
@@ -15,6 +15,7 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 from huggingface_hub import snapshot_download
 
+from .compaction import download_patterns, parquet_files
 from .config import DEFAULT_DATASET_ID
 
 SEMANTIC_PREFIXES = (
@@ -34,12 +35,12 @@ def load_remote_observations(
         snapshot_download(
             repo_id=dataset_id,
             repo_type="dataset",
-            allow_patterns="data/observations/**/*.parquet",
+            allow_patterns=download_patterns(["data/observations"]),
             token=token,
             max_workers=8,
         )
     )
-    files = sorted((snapshot / "data" / "observations").rglob("*.parquet"))
+    files = parquet_files(snapshot, "data/observations")
     if not files:
         raise FileNotFoundError(f"No observation partitions found in {dataset_id}")
     tables = [pq.ParquetFile(path).read() for path in files]
@@ -54,18 +55,14 @@ def load_remote_mart_tables(
         snapshot_download(
             repo_id=dataset_id,
             repo_type="dataset",
-            allow_patterns=[
-                pattern
-                for prefix in SEMANTIC_PREFIXES
-                for pattern in (f"{prefix}/*.parquet", f"{prefix}/**/*.parquet")
-            ],
+            allow_patterns=download_patterns(SEMANTIC_PREFIXES),
             token=token,
             max_workers=8,
         )
     )
     tables: dict[str, pa.Table | None] = {}
     for prefix in SEMANTIC_PREFIXES:
-        files = sorted((snapshot / prefix).rglob("*.parquet"))
+        files = parquet_files(snapshot, prefix)
         tables[prefix] = (
             pa.concat_tables(
                 [pq.ParquetFile(path).read() for path in files], promote_options="default"

--- a/src/bbc_news_logger/semantics.py
+++ b/src/bbc_news_logger/semantics.py
@@ -20,6 +20,7 @@ import pyarrow.parquet as pq
 from huggingface_hub import HfApi, snapshot_download
 from huggingface_hub.errors import HfHubHTTPError
 
+from .compaction import download_patterns, parquet_files
 from .config import DEFAULT_DATASET_ID
 from .deepseek import DEEPSEEK_MODEL, PROMPT_VERSION, DeepSeekBatchResult
 from .storage import write_parquet
@@ -83,10 +84,6 @@ class EmbeddingReport:
     remaining: int
 
 
-def _parquet_files(snapshot: Path, prefix: str) -> list[Path]:
-    return sorted((snapshot / prefix).rglob("*.parquet"))
-
-
 def download_dataset_tables(
     prefixes: Sequence[str],
     *,
@@ -99,18 +96,14 @@ def download_dataset_tables(
         snapshot_download(
             repo_id=dataset_id,
             repo_type="dataset",
-            allow_patterns=[
-                pattern
-                for prefix in prefixes
-                for pattern in (f"{prefix}/*.parquet", f"{prefix}/**/*.parquet")
-            ],
+            allow_patterns=download_patterns(prefixes),
             token=token or os.getenv("HF_TOKEN"),
             max_workers=8,
         )
     )
     result: dict[str, pa.Table | None] = {}
     for prefix in prefixes:
-        files = _parquet_files(snapshot, prefix)
+        files = parquet_files(snapshot, prefix)
         result[prefix] = (
             pa.concat_tables(
                 [pq.ParquetFile(path).read() for path in files], promote_options="default"

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -1,0 +1,60 @@
+from datetime import datetime, timezone
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from bbc_news_logger.compaction import compact_path, compact_table, download_patterns
+
+
+def test_download_patterns_include_base_and_incremental_shards() -> None:
+    assert download_patterns(["semantic/signals"]) == [
+        "compacted/semantic--signals.parquet",
+        "semantic/signals/*.parquet",
+        "semantic/signals/**/*.parquet",
+    ]
+    assert compact_path("data/observations") == "compacted/data--observations.parquet"
+
+
+def test_semantic_compaction_keeps_latest_row_per_content_hash(tmp_path) -> None:
+    schema = pa.schema(
+        [
+            pa.field("content_sha256", pa.string()),
+            pa.field("generated_at", pa.timestamp("us", tz="UTC")),
+            pa.field("summary", pa.string()),
+        ]
+    )
+    old = pa.Table.from_pylist(
+        [
+            {
+                "content_sha256": "same",
+                "generated_at": datetime(2026, 1, 1, tzinfo=timezone.utc),
+                "summary": "old",
+            }
+        ],
+        schema=schema,
+    )
+    new = pa.Table.from_pylist(
+        [
+            {
+                "content_sha256": "same",
+                "generated_at": datetime(2026, 1, 2, tzinfo=timezone.utc),
+                "summary": "new",
+            },
+            {
+                "content_sha256": "other",
+                "generated_at": datetime(2026, 1, 1, tzinfo=timezone.utc),
+                "summary": "other",
+            },
+        ],
+        schema=schema,
+    )
+    paths = [tmp_path / "old.parquet", tmp_path / "new.parquet"]
+    pq.write_table(old, paths[0])
+    pq.write_table(new, paths[1])
+
+    rows = compact_table("semantic/signals", paths).to_pylist()
+
+    assert {row["content_sha256"]: row["summary"] for row in rows} == {
+        "same": "new",
+        "other": "other",
+    }


### PR DESCRIPTION
## Summary
- add atomic LSM-style compaction for observations, article snapshots, semantic signals, and embeddings
- teach dashboard, embedding/enrichment, clustering, and Fenic readers to combine compact bases with incremental shards
- document the maintenance command and cover base/incremental loading plus semantic deduplication

## Live data migration
- atomically replaced 1,053 Parquet source objects with 4 compact bases
- retained 172,027 observations, 18,938 article snapshots, and 17,462 labels/embeddings
- recurring events remains one replace-in-place object

## Verification
- 39 Python tests pass
- Ruff and git diff checks pass
- clean-cache production mart build fetched exactly 5 files and retained 100% coverage