### PR TITLE
Stop Signals navigation freezes

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ The historical migration preserved 171,887 position observations and 18,892 arti
 1,223 audited destination files. See `migration/manifest.json` in the curated dataset for source
 and destination hashes, row counts, and the source commit.
 
+The low-cost data-app architecture was informed by Spicy Data's
+[“A live data app for $0: DuckDB, Astro, and no BI tool”](https://spicydata.ai/blog/zero-dollar-data-app/).
+Its pull → DuckDB marts → Astro interface → scheduled refresh pattern is a useful reference for
+building a bespoke public data product without a warehouse or per-seat BI service.
+
 ## Local development
 
 Requires Python 3.10–3.12 and [uv](https://docs.astral.sh/uv/). The dashboard requires Node 22.

--- a/web/src/pages/signals.astro
+++ b/web/src/pages/signals.astro
@@ -115,12 +115,19 @@ import Layout from "../layouts/Layout.astro";
           <h2 id="trend-heading">Inspect a signal over time</h2>
           <p>Counts are fetched article versions, not audience size. The computed findings above are the starting point; this chart exposes the underlying daily series.</p>
         </div>
-        <form class="signals-controls" id="trend-filters">
+        <form class="signals-controls" id="trend-filters" hidden>
           <div class="field"><label for="dimension">Group by</label><select id="dimension" name="dimension"><option value="theme">Theme</option><option value="topic">Topic</option><option value="story_form">Story form</option><option value="event_type">Event type</option></select></div>
           <div class="field"><label for="signal-value">Signal</label><select id="signal-value" name="value"><option>Loading…</option></select></div>
         </form>
       </div>
-      <figure class="trend-panel">
+      <div class="deferred-tool" id="trend-loader">
+        <div>
+          <strong>Open the detailed trend explorer</strong>
+          <p>This downloads the multi-megabyte daily trend mart only when you ask for it.</p>
+        </div>
+        <button class="button secondary" id="load-trends" type="button">Load trends</button>
+      </div>
+      <figure class="trend-panel" id="trend-explorer" hidden>
         <figcaption id="trend-caption">Loading semantic trend mart…</figcaption>
         <svg id="trend-chart" class="trend-chart" role="img" aria-labelledby="trend-caption"></svg>
         <div class="table-wrap trend-table-wrap"><table><caption class="sr-only">Daily counts for the selected semantic signal</caption><thead><tr><th>Date</th><th>Articles</th></tr></thead><tbody id="trend-table"><tr><td colspan="2" class="loading">Loading trend data…</td></tr></tbody></table></div>
@@ -130,9 +137,16 @@ import Layout from "../layouts/Layout.astro";
     <section class="signals-section" aria-labelledby="recurring-heading">
       <div class="signals-heading">
         <div><p class="context-label">Conservative event matching</p><h2 id="recurring-heading">Stories that return</h2><p>Every cross-article link requires embedding similarity plus compatible event labels or named entities.</p></div>
-        <div class="field event-filter"><label for="event-query">Filter clusters</label><input id="event-query" type="search" placeholder="Search events or themes" autocomplete="off" /></div>
+        <div class="field event-filter" id="event-filter" hidden><label for="event-query">Filter clusters</label><input id="event-query" type="search" placeholder="Search events or themes" autocomplete="off" /></div>
       </div>
-      <div class="event-explorer">
+      <div class="deferred-tool" id="event-loader">
+        <div>
+          <strong>Open the recurring-story explorer</strong>
+          <p>This downloads full cluster timelines only when you ask for them.</p>
+        </div>
+        <button class="button secondary" id="load-events" type="button">Load recurring stories</button>
+      </div>
+      <div class="event-explorer" id="event-explorer" hidden>
         <div class="event-index">
           <div class="event-pagination">
             <span id="event-page-status" aria-live="polite">Loading recurring stories…</span>
@@ -149,8 +163,6 @@ import Layout from "../layouts/Layout.astro";
   </div>
 
   <script>
-    import SemanticSearchWorker from "../workers/semantic-search.worker?worker";
-
     interface TrendRow { observed_date: string; dimension: string; value: string; article_count: number }
     interface EventArticle { story_id: string; title: string; url: string; fetched_at: string; best_position: number | null; surfaces: string[] }
     interface EventCluster { cluster_id: string; label: string; event_type: string; themes: string[]; first_seen: string; last_seen: string; article_count: number; version_count: number; articles: EventArticle[] }
@@ -195,7 +207,19 @@ Every substantive claim must cite at least one supplied source. Do not invent so
     const control = (selector: string): HTMLInputElement | HTMLSelectElement => { const result = document.querySelector<HTMLInputElement | HTMLSelectElement>(selector); if (!result) throw new Error(`Missing control: ${selector}`); return result; };
     const label = (value: string) => value.replaceAll("_", " ");
 
-    const semanticWorker = new SemanticSearchWorker();
+    let semanticWorker: Worker | null = null;
+    let semanticWorkerLoad: Promise<Worker> | null = null;
+
+    function getSemanticWorker(): Promise<Worker> {
+      if (semanticWorker) return Promise.resolve(semanticWorker);
+      if (semanticWorkerLoad) return semanticWorkerLoad;
+      semanticWorkerLoad = import("../workers/semantic-search.worker?worker").then(({ default: SemanticSearchWorker }) => {
+        semanticWorker = new SemanticSearchWorker();
+        semanticWorker.addEventListener("message", handleSemanticMessage);
+        return semanticWorker;
+      });
+      return semanticWorkerLoad;
+    }
 
     function startSemanticSearch() {
       if (semanticStarted) return;
@@ -203,12 +227,16 @@ Every substantive claim must cite at least one supplied source. Do not invent so
       const bar = document.querySelector<HTMLProgressElement>("#model-progress");
       if (bar) bar.hidden = false;
       setModelState("Downloading the semantic index…");
-      semanticWorker.postMessage({
-        type: "init",
-        metadataUrl: new URL(`${base}data/semantic-documents.json`, location.href).href,
-        vectorsUrl: new URL(`${base}data/semantic-vectors.i8`, location.href).href,
-        loadModel: true,
-      });
+      void getSemanticWorker().then((worker) => worker.postMessage({
+          type: "init",
+          metadataUrl: new URL(`${base}data/semantic-documents.json`, location.href).href,
+          vectorsUrl: new URL(`${base}data/semantic-vectors.i8`, location.href).href,
+          loadModel: true,
+        })).catch(() => {
+          semanticStarted = false;
+          setModelState("Semantic search could not start", "error");
+          element("#search-summary").textContent = "The browser could not start the local semantic worker.";
+        });
     }
 
     function setModelState(message: string, state: "loading" | "ready" | "error" = "loading") {
@@ -240,7 +268,7 @@ Every substantive claim must cite at least one supplied source. Do not invent so
         const panel = element("#research-answer"); panel.hidden = false;
         panel.innerHTML = `<p class="research-state">Retrieving the strongest archive evidence before asking DeepSeek…</p>`;
       }
-      semanticWorker.postMessage({ type: "search", requestId, query, filters: { surface: control("#semantic-surface").value, topic: control("#semantic-topic").value, storyForm: control("#semantic-form").value } });
+      void getSemanticWorker().then((worker) => worker.postMessage({ type: "search", requestId, query, filters: { surface: control("#semantic-surface").value, topic: control("#semantic-topic").value, storyForm: control("#semantic-form").value } }));
       const params = new URLSearchParams(location.search); params.set("q", query); history.replaceState(null, "", `${location.pathname}?${params}`);
     }
 
@@ -377,7 +405,7 @@ Every substantive claim must cite at least one supplied source. Do not invent so
       }
     }
 
-    semanticWorker.addEventListener("message", (event: MessageEvent) => {
+    function handleSemanticMessage(event: MessageEvent) {
       const message = event.data;
       if (message.type === "status") setModelState(message.message);
       if (message.type === "index-ready") {
@@ -405,7 +433,7 @@ Every substantive claim must cite at least one supplied source. Do not invent so
       if (message.type === "search-results" && message.requestId === requestId) renderSearchResults(message.results, message.mode);
       if (message.type === "fatal-error") { setModelState("Semantic index unavailable", "error"); element("#search-summary").textContent = message.message; }
       if (message.type === "search-error" && message.requestId === requestId) { element("#search-summary").textContent = message.message; element("#semantic-results").innerHTML = `<p class="loading">Search could not be completed.</p>`; }
-    });
+    }
 
     element("#semantic-search-form").addEventListener("submit", (event) => {
       event.preventDefault();
@@ -432,7 +460,7 @@ Every substantive claim must cite at least one supplied source. Do not invent so
       element("#surface-differences").innerHTML = findings.surfaceDifferences.length ? findings.surfaceDifferences.slice(0, 6).map((row) => `<div class="finding-row"><strong>${escape(row.theme)}</strong><span class="change ${row.differencePercentagePoints >= 0 ? "positive" : "negative"}">${row.differencePercentagePoints >= 0 ? "+" : ""}${row.differencePercentagePoints.toFixed(2)} pp</span><small>${row.differencePercentagePoints >= 0 ? "more common in Most Read" : "more common on the front page"}</small></div>`).join("") : `<p class="loading">Surface differences need more labelled stories.</p>`;
       element("#story-forms").innerHTML = findings.storyForms.length ? findings.storyForms.slice(0, 7).map((row) => `<div class="form-row"><span>${escape(label(row.storyForm))}</span><span class="form-bar"><i style="width:${Math.min(row.share, 100)}%"></i></span><strong>${row.share.toFixed(1)}%</strong></div>`).join("") : `<p class="loading">Story-form labels are not available yet.</p>`;
       element("#returning-findings").innerHTML = findings.returningStories.length ? findings.returningStories.slice(0, 5).map((event) => `<button type="button" class="finding-event" data-event-id="${escape(event.cluster_id)}"><strong>${escape(event.label)}</strong><span>${event.article_count} articles · latest ${date.format(new Date(event.last_seen))}</span></button>`).join("") : `<p class="loading">No conservative recurring-story clusters yet.</p>`;
-      element("#returning-findings").querySelectorAll<HTMLButtonElement>("button[data-event-id]").forEach((button) => button.addEventListener("click", () => { void loadEventData().then(() => { selectEvent(button.dataset.eventId ?? ""); document.querySelector("#recurring-heading")?.scrollIntoView(); }); }));
+      element("#returning-findings").querySelectorAll<HTMLButtonElement>("button[data-event-id]").forEach((button) => button.addEventListener("click", () => { void revealEventData().then(() => { selectEvent(button.dataset.eventId ?? ""); document.querySelector("#recurring-heading")?.scrollIntoView(); }); }));
     }
 
     function valuesForDimension(dimension: string): string[] { const totals = new Map<string, number>(); trends.filter((row) => row.dimension === dimension).forEach((row) => totals.set(row.value, (totals.get(row.value) ?? 0) + row.article_count)); return [...totals].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0])).map(([value]) => value); }
@@ -490,13 +518,23 @@ Every substantive claim must cite at least one supplied source. Do not invent so
       });
       return eventLoad;
     }
-    function loadNearViewport(target: Element | null, load: () => Promise<void>) {
-      if (!target || !("IntersectionObserver" in window)) { void load(); return; }
-      const observer = new IntersectionObserver((entries) => {
-        if (entries.some((entry) => entry.isIntersecting)) { observer.disconnect(); void load(); }
-      }, { rootMargin: "400px 0px" });
-      observer.observe(target);
+
+    function revealTrendData(): Promise<void> {
+      element("#trend-loader").hidden = true;
+      element("#trend-filters").hidden = false;
+      element("#trend-explorer").hidden = false;
+      return loadTrendData();
     }
+
+    function revealEventData(): Promise<void> {
+      element("#event-loader").hidden = true;
+      element("#event-filter").hidden = false;
+      element("#event-explorer").hidden = false;
+      return loadEventData();
+    }
+    element("#load-trends").addEventListener("click", () => void revealTrendData());
+    element("#load-events").addEventListener("click", () => void revealEventData());
+
     Promise.all([
       fetch(`${base}data/manifest.json`).then((response) => response.json()),
       fetch(`${base}data/semantic-findings.json`).then((response) => response.json()),
@@ -505,8 +543,6 @@ Every substantive claim must cite at least one supplied source. Do not invent so
       const semantic = manifest.semantics ?? { signalCount: 0, articleVersionCount: 0, coveragePercent: 0, recurringEventCount: 0 };
       element("#coverage").textContent = `${semantic.coveragePercent.toFixed(1)}%`; element("#signal-count").textContent = number.format(semantic.signalCount); element("#event-count").textContent = number.format(semantic.recurringEventCount); element("#coverage-note").textContent = semantic.coveragePercent < 100 ? `Historical enrichment is in progress. ${number.format(semantic.articleVersionCount - semantic.signalCount)} article versions remain.` : "All currently archived article versions have structured signals.";
       const query = new URLSearchParams(location.search).get("q"); if (query) { control("#semantic-query").value = query; element("#search-summary").textContent = "The linked question is ready. Choose Ask the archive or Find sources only to run semantic search."; }
-      loadNearViewport(document.querySelector("#trend-heading"), loadTrendData);
-      loadNearViewport(document.querySelector("#recurring-heading"), loadEventData);
     }).catch(() => { element("#coverage").textContent = "Unavailable"; element("#coverage-note").textContent = "The static semantic marts could not be loaded."; });
   </script>
 </Layout>

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -268,6 +268,10 @@
   .finding-event strong, .finding-event span { display: block; }
   .finding-event strong { font-size: .78rem; line-height: 1.3; }
   .finding-event span { margin-top: .2rem; color: var(--muted); font-size: .68rem; }
+  .deferred-tool { display: flex; align-items: center; justify-content: space-between; gap: 1.5rem; min-height: 8rem; padding: 1.35rem 1.5rem; border: 1px solid var(--line-strong); background: var(--paper-strong); }
+  .deferred-tool strong { display: block; }
+  .deferred-tool p { max-width: 58ch; margin-top: .35rem; color: var(--muted); font-size: .8rem; }
+  .deferred-tool .button { flex: none; }
   .trend-panel { background: var(--dark); color: white; padding: 1.5rem; }
   .trend-panel figcaption { color: var(--dark-muted); font-size: .84rem; padding-bottom: 1rem; border-bottom: 1px solid var(--dark-line); }
   .trend-chart { width: 100%; height: 16rem; margin-top: 1rem; }
@@ -366,6 +370,8 @@
   .findings-grid { grid-template-columns: 1fr 1fr; }
   .finding-panel:nth-child(2) { border-right: 0; }
   .finding-panel:nth-child(-n+2) { border-bottom: 1px solid var(--line); }
+  .deferred-tool { align-items: stretch; flex-direction: column; }
+  .deferred-tool .button { align-self: start; }
   .event-explorer { grid-template-columns: 1fr; }
   .event-index { border-right: 0; border-bottom: 1px solid var(--line-strong); }
   .event-list { max-height: 24rem; }


### PR DESCRIPTION
## What changed

- create the semantic worker only after a search is submitted
- replace viewport-triggered downloads of the large trend and recurring-story marts with explicit load controls
- keep the lightweight computed findings available immediately
- add the requested Spicy Data architecture reference to the README

## Root cause

The previous optimisation still constructed a worker during module evaluation and used a 400px `IntersectionObserver` margin for multi-megabyte marts. Depending on viewport and device layout, scrolling or navigation could therefore start worker parsing and large JSON work almost immediately.

## Impact

Initial Signals navigation now fetches only the page shell, page script, manifest, small findings mart, and favicon. Semantic search, detailed trends, and full recurring timelines remain available on demand.

## Validation

- `npm run build` (includes Astro check, production build, and built-path validation)
- 0 Astro errors, warnings, or hints
- headless Chromium initial-request trace confirmed no semantic worker, vector index, model, trend mart, or recurring-event mart is requested on navigation