### PR TITLE
Update public methodology

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Append-only Parquet shards make routine updates small. A weekly compare-and-swap
 older shards into compressed base files without racing new collection writes. Dashboard and Fenic
 readers see the base and incremental layers as the same logical tables.
 
-## How we built it
+## How it was made
 
 BBC News Analyser was built as a sequence of small, auditable systems rather than as one large
 application. Each new capability had to preserve the data already collected and remain cheap to
@@ -96,11 +96,11 @@ run unattended.
    interface keeps retrieval results visible so a generated answer can always be checked against
    the archive.
 
-The development process followed the same evidence-first pattern. A human set the research goals,
-interpretive limits, and cost boundaries; an AI coding agent inspected the repository and live
-outputs, implemented scoped changes, ran tests and workflows, and measured the deployed result.
-Each iteration was then reviewed against real data and real browser behaviour before the next one
-began.
+The development process followed the same evidence-first pattern. I set the research goals,
+interpretive limits, and cost boundaries, then used an AI coding agent to inspect the repository
+and live outputs, implement scoped changes, run tests and workflows, and measure the deployed
+result. I reviewed each iteration against real data and real browser behaviour before starting the
+next one.
 
 That measurement loop mattered. For example, profiling a frozen trends interface showed that it
 was creating 26,521 theme options and repeatedly scanning 70,685 rows on the browser thread. The
@@ -111,13 +111,16 @@ technology in the architecture.
 
 ## Dataset
 
-The main public dataset exposes three core configurations:
+The main public dataset exposes six configurations:
 
 | Configuration | Grain |
 | --- | --- |
 | `observations` | One row for each captured story position in each successful scrape |
 | `article_snapshots` | Parsed metadata and text for each daily article URL set |
 | `scrape_runs` | Validation and operational metadata for each collection attempt |
+| `story_signals` | Versioned DeepSeek labels and summaries for each analysed content hash |
+| `article_embeddings` | Normalized 384-dimensional BGE Small vectors for semantic retrieval |
+| `recurring_events` | Reproducible recurring-story membership derived from vectors and structured evidence |
 
 Stable `story_id` values come from normalized canonical URLs. Every Parquet file carries a schema
 version, and publication uses idempotent record keys so rerunning a workflow does not duplicate a

--- a/web/src/pages/methodology.astro
+++ b/web/src/pages/methodology.astro
@@ -3,76 +3,100 @@ import Layout from "../layouts/Layout.astro";
 ---
 
 <Layout
-  title="Methodology — BBC News Analyser"
-  description="Collection, storage, validation, and limitations for the BBC News Surface Observations dataset."
+  title="Methodology | BBC News Analyser"
+  description="How BBC News Analyser collects, stores, enriches, and presents its independent BBC News archive."
   current="methodology"
 >
   <div class="shell">
     <header class="page-intro">
       <div>
         <p class="eyebrow">Versioned methodology</p>
-        <h1>A transparent collection, including its limits.</h1>
+        <h1>How the archive is collected, analysed, and interpreted.</h1>
       </div>
-      <p>Dataset schema version 2 · selector version 2026-07 · timestamps and daily partitions use UTC.</p>
+      <p>Dataset schema version 1 · selector version 2026-07 · timestamps and daily partitions use UTC.</p>
     </header>
 
     <div class="method-grid">
       <nav class="method-nav" aria-label="Methodology sections">
         <a href="#collection">Collection</a>
-        <a href="#contract">Data contract</a>
-        <a href="#migration">Legacy migration</a>
-        <a href="#validation">Validation</a>
+        <a href="#contract">Storage and schemas</a>
+        <a href="#migration">Historical migration</a>
+        <a href="#validation">Validation and operations</a>
         <a href="#semantics">Semantic analysis</a>
+        <a href="#interface">Interface and cited synthesis</a>
+        <a href="#process">How it was made</a>
         <a href="#limitations">Limitations</a>
       </nav>
       <article class="prose">
         <section id="collection">
           <h2>Collection</h2>
-          <p>GitHub Actions requests the BBC News homepage once per hour. The collector records the first ten linked stories in two page regions: the Most Read ordered list and the leading front-page promo grid.</p>
-          <p>Each row receives a stable story identifier derived from its canonical URL and a scrape identifier shared by the rows from one response. Query parameters and URL fragments are removed before IDs are generated.</p>
-          <div class="notice"><strong>Fail-closed behavior:</strong> if either expected surface returns no stories, the run raises an error and publishes no partial observation batch.</div>
+          <p>GitHub Actions requests the BBC News homepage once per hour. The collector records the first ten linked stories in two page regions: the Most Read ordered list and the leading front-page promo grid. This is a record of selected web surfaces, not every BBC product or article.</p>
+          <p>Each row receives a stable story identifier derived from its normalized canonical URL and a scrape identifier shared by every row from one response. Query parameters and URL fragments are removed before identifiers are generated.</p>
+          <p>A separate daily job collects the previous day’s distinct article URLs. Parsed metadata and plain text go to the curated dataset; the larger raw HTML field goes to a companion dataset.</p>
+          <div class="notice"><strong>Fail-closed collection:</strong> if either expected homepage surface returns no stories, the run fails and publishes no partial observation batch. A gap remains visible instead of being mistaken for a genuine absence of stories.</div>
         </section>
 
         <section id="contract">
-          <h2>Data contract</h2>
-          <p>Small, append-oriented Parquet partitions replace mutable daily CSV files. A weekly compare-and-swap compaction folds older shards into four base files without racing new collection writes. Zstandard compression and dictionary encoding reduce transfer and storage. Raw article HTML is held separately so ordinary analysis only downloads typed metadata and plain text.</p>
+          <h2>Storage and schemas</h2>
+          <p>The repository contains code, schemas, tests, and interface assets. Generated records are published as typed, Zstandard-compressed Parquet on Hugging Face so Git history stays small and data consumers can select only the tables they need.</p>
+          <p>The <a href="https://huggingface.co/datasets/AlastairH/bbc-news-logger">curated dataset</a> exposes six configurations. The <a href="https://huggingface.co/datasets/AlastairH/bbc-news-logger-raw">raw companion</a> holds article HTML and joins to parsed snapshots with <code>snapshot_id</code>.</p>
           <dl class="schema">
-            <div><dt>observed_at</dt><dd>Timezone-aware UTC timestamp for the homepage response.</dd></div>
-            <div><dt>surface</dt><dd><code>front_page</code> or <code>most_read</code>.</dd></div>
-            <div><dt>position</dt><dd>One-indexed order within the captured page region.</dd></div>
-            <div><dt>story_id</dt><dd>Stable SHA-256-derived key for a normalized canonical URL.</dd></div>
-            <div><dt>scrape_id</dt><dd>Stable key shared by every observation from one scrape.</dd></div>
+            <div><dt>observations</dt><dd>One row per captured story position in each successful hourly scrape.</dd></div>
+            <div><dt>article_snapshots</dt><dd>Parsed metadata and text for each daily article URL set.</dd></div>
+            <div><dt>scrape_runs</dt><dd>HTTP, selector, validation, timing, and workflow provenance for each new run.</dd></div>
+            <div><dt>story_signals</dt><dd>Versioned model labels, summaries, entities, event evidence, token use, and cost.</dd></div>
+            <div><dt>article_embeddings</dt><dd>Normalized 384-dimensional BGE Small vectors keyed by content hash.</dd></div>
+            <div><dt>recurring_events</dt><dd>Reproducible recurring-story cluster membership and supporting scores.</dd></div>
           </dl>
+          <p>Routine publication writes small, immutable shards with idempotent record keys. Weekly compare-and-swap compaction folds older shards into compressed base files, but only if the source revision is unchanged. Readers combine each compact base with newer shards as one logical table, so collection can continue while compaction runs.</p>
+          <p>Important join keys are <code>scrape_id</code> for one homepage response, <code>story_id</code> for a normalized canonical URL, <code>snapshot_id</code> for a fetched article version, and <code>content_sha256</code> for semantic derivatives. Every core Parquet file carries schema-version metadata.</p>
         </section>
 
         <section id="migration">
-          <h2>Legacy migration</h2>
+          <h2>Historical migration</h2>
           <p>Historical loose CSVs, monthly ZIP archives, and article Parquet files are converted without altering the originals. A manifest records the source Git commit, SHA-256 for each source and destination, and all row counts.</p>
           <p>The old article writer placed URL values in <code>first_appeared_at</code>. The migration replaces those values with the earliest matching observation when possible. It also marks historical fetch times as inferred because only the daily filename survives.</p>
           <p>Historical front-page files had no position field. Their position is reconstructed from row order within each scrape and documented as such.</p>
         </section>
 
         <section id="validation">
-          <h2>Validation and reproducibility</h2>
-          <p>Parser fixtures cover both page regions, typed Arrow schemas are asserted in tests, publication upserts are idempotent, and dashboard marts are rebuilt from the public dataset rather than committed source data.</p>
-          <p>New collection runs include HTTP status, selector version, per-surface counts, workflow URL, and explicit success state. GitHub Actions uses a locked environment and concurrency controls, with read-only repository permissions except where Pages deployment requires them.</p>
+          <h2>Validation and operations</h2>
+          <p>Parser fixtures cover both page regions, tests assert typed Arrow schemas, publication keys are idempotent, and dashboard marts are rebuilt from the public dataset rather than from generated files committed to Git.</p>
+          <p>New collection runs include HTTP status, selector version, per-surface counts, workflow URL, timestamps, and explicit success state. Locked dependencies, workflow timeouts, concurrency controls, and least-privilege permissions make scheduled behavior inspectable.</p>
+          <p>Collection runs hourly, article snapshots run daily, semantic analysis follows successful article collection, compaction runs weekly, and Pages rebuilds every three hours and after relevant changes. The semantic job processes only missing content hashes, while compaction retries if another publication changes the dataset revision.</p>
         </section>
 
         <section id="semantics">
           <h2>Semantic analysis</h2>
-          <p>Each distinct article content hash can receive two versioned derivatives. BGE Small produces a normalized 384-dimensional vector from the headline and opening article text. DeepSeek V4 Flash produces a validated topic, themes, story form, event type, event label, summary, and named entities.</p>
-          <p>Paid requests contain no more than eight articles and run with a maximum concurrency of four. Results are committed to a synchronous local checkpoint before more paid work starts, then uploaded as content-addressed Parquet shards. The process enforces a $1 process ceiling, a $7.50 historical ceiling, and a $1 monthly incremental ceiling.</p>
-          <p>The static site publishes one newest embedded version per story as a row-aligned, int8-quantised vector index. On the Signals page, the index and BGE Small load through Transformers.js only after a visitor starts a search; the WASM model uses one worker thread and query text is not sent to this project. The Explore page uses the same index to rank related coverage without loading the query model.</p>
+          <p>Each distinct article content hash can receive two versioned derivatives. BGE Small produces a normalized 384-dimensional vector from the headline and opening article text. DeepSeek V4 Flash produces a validated topic, reusable themes, story form, event type, event label, summary, and named entities.</p>
+          <p>Embeddings are free model inference. Paid label requests contain no more than eight articles and run with a maximum concurrency of four. Each successful response is committed synchronously to a SQLite checkpoint before the next wave of requests, then buffered into immutable, content-addressed Parquet shards. A failed or timed-out run resumes from completed hashes rather than repeating paid work.</p>
+          <p>The enrichment code enforces a $1 process ceiling, a $7.50 historical ceiling, and a $1 monthly incremental ceiling. Persistent dataset rows and unpublished checkpoint rows both count toward the relevant ledger. Ambiguous failures are recorded without an automatic paid retry.</p>
           <p>Overview findings are computed only from completed structured labels. Theme momentum compares theme share in adjacent 14-day windows, normalised by the number of labelled article versions in each window. Surface differences compare each theme's labelled share on the front page with its share in Most Read. Counts describe fetched article versions and captured positions, not readership.</p>
           <p>Recurring stories are joined conservatively. Versions with the same story identifier stay together; a different story must fall within 45 days, match the cluster anchor's event type, and combine strong vector similarity with shared named entities or event-label evidence. Anchor validation prevents a chain of individually similar articles from merging unrelated events. These outputs are discovery aids rather than editorial classifications or verified factual claims.</p>
-          <div class="notice"><strong>Hosted cited analysis.</strong> “Ask the archive” sends at most twenty locally retrieved BBC evidence rows to a lightweight Cloudflare Worker for bounded DeepSeek synthesis. The prompt asks the model to rank relevance, distinguish reported claims from established facts, and identify counter-evidence. Visitors can choose Fast, Reasoned, or Deep analysis; the latter two enable DeepSeek thinking with a bounded token allowance. Private reasoning is neither stored nor displayed, only the final cited answer is returned. Search, related coverage, trends, and findings remain local or static and usable when the optional service is unavailable or over budget.</div>
+          <p><a href="https://github.com/typedef-ai/fenic">Fenic</a> provides an optional local catalog and bounded MCP research interface over the same public tables. It is not required for collection, enrichment, or the website.</p>
+        </section>
+
+        <section id="interface">
+          <h2>Interface and cited synthesis</h2>
+          <p>DuckDB turns the public Parquet tables into compact, browser-ready marts during the Pages build. Astro produces the static site. No permanent application server is required for ordinary exploration.</p>
+          <p>The newest embedded version of each story is published as a row-aligned, int8-quantised vector index. On Ask &amp; analyse, the index and BGE Small query model load only after a visitor starts a semantic search. Retrieval runs in a browser worker, and the query text is not sent to this project. Explore uses the same index for related coverage without loading the query model.</p>
+          <p>Large trend and recurring-story marts load in stages after the headline findings. Parsing, indexing, filtering, and semantic comparisons happen off the main browser thread so the page stays responsive while data is prepared.</p>
+          <div class="notice"><strong>Optional cited synthesis:</strong> Ask the archive sends the question and at most twenty locally retrieved BBC evidence rows to a rate-limited Cloudflare Worker. DeepSeek is instructed to rank relevance, separate reported claims from established facts, surface disagreement, and cite numbered evidence. Fast, Reasoned, and Deep modes use bounded output allowances; private model reasoning is neither stored nor displayed. A visitor-supplied DeepSeek key remains in session storage for that browser tab and is sent directly to DeepSeek. Search, related coverage, trends, and findings remain available when synthesis is offline or over budget.</div>
+        </section>
+
+        <section id="process">
+          <h2>How it was made</h2>
+          <p>This is a solo development project. I set the research questions, interpretive limits, and cost boundaries, and used an AI coding agent to inspect the code and live data, implement scoped changes, run tests and workflows, and measure the deployed result. I reviewed each iteration against the archive and real browser behaviour before moving to the next one.</p>
+          <p>The system was built in layers: stabilise fail-closed collection, migrate history with an audit trail, make expensive work incremental and checkpointed, place each job on the smallest suitable compute, then add retrieval-grounded synthesis without making the archive depend on it.</p>
+          <p>Measurements shaped the architecture. A frozen trends view, for example, was traced to 26,521 theme options and repeated scans of 70,685 rows on the browser thread. Moving the mart into a Web Worker, ranking only active signals, and staging its load fixed the interaction without adding a server.</p>
+          <p>The low-cost data-app design was informed by <a href="https://spicydata.ai/blog/zero-dollar-data-app/">Spicy Data’s DuckDB and Astro architecture</a>. The retrieval and synthesis approach also draws on the <a href="https://github.com/typedef-ai/fenic-examples/tree/main/hn_agent">Fenic Hacker News agent example</a>.</p>
         </section>
 
         <section id="limitations">
           <h2>Interpretive limitations</h2>
           <p>Front-page placement is not a direct measure of editorial importance, and Most Read rank is not a readership count. The capture covers selected regions of one web page, not apps, regional variants, personalization, or every BBC property.</p>
           <p>Page structure can change without notice. Fail-closed validation makes gaps visible but cannot reconstruct missed observations, and GitHub can delay scheduled starts. The overview chart excludes the still-incomplete current UTC day. Article text extraction may include captions, related links, or interface text, and linked content can change between first observation and daily fetch.</p>
-          <p>Semantic coverage may be incomplete while a backfill is running. Model outputs can be inconsistent or wrong, and similarity thresholds can join or separate stories imperfectly. The Signals page displays coverage, while the dataset retains model, prompt, and input versions for reproducibility.</p>
+          <p>Semantic coverage may be incomplete while a backfill is running. Model outputs can be inconsistent or wrong, and similarity thresholds can join or separate stories imperfectly. Coverage must be considered when comparing periods. The interface displays current coverage, while the dataset retains model, prompt, input, and clustering versions for reproducibility.</p>
           <p>This project is independent and is not affiliated with or endorsed by the BBC. BBC content remains subject to its terms and copyright.</p>
         </section>
       </article>

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -178,7 +178,9 @@
   .method-nav a { display: block; padding: .7rem 0; border-bottom: 1px solid var(--line); color: var(--muted); font-size: .82rem; text-decoration: none; }
   .prose section { padding: 0 0 3.8rem; }
   .prose h2 { font-size: clamp(1.7rem, 3vw, 2.7rem); margin-bottom: 1.2rem; }
+  .prose p { max-width: 72ch; text-wrap: pretty; }
   .prose p + p { margin-top: 1rem; }
+  .prose a { color: var(--signal); font-weight: 620; }
   .prose code { font: .85em var(--mono); background: var(--signal-soft); padding: .12rem .3rem; }
   .schema { margin-top: 1.5rem; border-top: 1px solid var(--line-strong); }
   .schema div { display: grid; grid-template-columns: 11rem 1fr; gap: 1rem; padding: .65rem 0; border-bottom: 1px solid var(--line); }


### PR DESCRIPTION
## What changed

- Rename the engineering section to **How it was made** and make the solo-development voice explicit.
- Document all six curated dataset configurations in the public README.
- Bring the Methodology page up to date with the current storage, compaction, semantic enrichment, browser-worker, Cloudflare synthesis, and optional Fenic architecture.
- Add the solo, AI-assisted engineering process and the project references to the Methodology page.
- Correct the displayed dataset schema version from 2 to 1.

## Why

The Methodology page predated the current public README and no longer described several important parts of the deployed system. The collective wording also implied a team project.

## Validation

- `uv run --no-sync ruff check .`
- `uv run --no-sync pytest -q` (39 passed)
- `git diff --check`

The Astro production build is delegated to PR CI because Node.js is unavailable in the current local shell.